### PR TITLE
Support for v2.x of the API

### DIFF
--- a/src/Api/Payment.php
+++ b/src/Api/Payment.php
@@ -136,7 +136,6 @@ class Payment extends ApiBase implements PaymentInterface
         $resource = new GetOrderStatus(
             $this->app,
             $this->getSubscriptionKey(),
-            $this->getMerchantSerialNumber(),
             $order_id
         );
         $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
@@ -155,7 +154,6 @@ class Payment extends ApiBase implements PaymentInterface
         $resource = new GetPaymentDetails(
             $this->app,
             $this->getSubscriptionKey(),
-            $this->getMerchantSerialNumber(),
             $order_id
         );
         $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));

--- a/src/Api/Payment.php
+++ b/src/Api/Payment.php
@@ -71,7 +71,7 @@ class Payment extends ApiBase implements PaymentInterface
         VippsInterface $app,
         $subscription_key,
         $merchant_serial_number,
-        $custom_path = 'Ecomm'
+        $custom_path = 'ecomm'
     ) {
         parent::__construct($app, $subscription_key);
         $this->merchantSerialNumber = $merchant_serial_number;
@@ -94,7 +94,7 @@ class Payment extends ApiBase implements PaymentInterface
                     ->setTransactionText($text)
             );
         $resource = new CancelPayment($this->app, $this->getSubscriptionKey(), $order_id, $request);
-        $resource->setPath(str_replace('Ecomm', $this->customPath, $resource->getPath()));
+        $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
         /** @var \zaporylie\Vipps\Model\Payment\ResponseCancelPayment $response */
         $response = $resource->call();
         return $response;
@@ -120,7 +120,7 @@ class Payment extends ApiBase implements PaymentInterface
             $request->getTransaction()->setAmount($amount);
         }
         $resource = new CapturePayment($this->app, $this->getSubscriptionKey(), $order_id, $request);
-        $resource->setPath(str_replace('Ecomm', $this->customPath, $resource->getPath()));
+        $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
         /** @var \zaporylie\Vipps\Model\Payment\ResponseCapturePayment $response */
         $response = $resource->call();
         return $response;
@@ -139,7 +139,7 @@ class Payment extends ApiBase implements PaymentInterface
             $this->getMerchantSerialNumber(),
             $order_id
         );
-        $resource->setPath(str_replace('Ecomm', $this->customPath, $resource->getPath()));
+        $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
         /** @var \zaporylie\Vipps\Model\Payment\ResponseGetOrderStatus $response */
         $response = $resource->call();
         return $response;
@@ -158,7 +158,7 @@ class Payment extends ApiBase implements PaymentInterface
             $this->getMerchantSerialNumber(),
             $order_id
         );
-        $resource->setPath(str_replace('Ecomm', $this->customPath, $resource->getPath()));
+        $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
         /** @var \zaporylie\Vipps\Model\Payment\ResponseGetPaymentDetails $response */
         $response = $resource->call();
         return $response;
@@ -167,7 +167,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function initiatePayment($order_id, $mobile_number, $amount, $text, $callback, $refOrderID = null)
+    public function initiatePayment($order_id, $mobile_number, $amount, $text, $callback, $fallback, $refOrderID = null)
     {
         // Create Request object based on data passed to this method.
         $request = (new RequestInitiatePayment())
@@ -178,6 +178,7 @@ class Payment extends ApiBase implements PaymentInterface
             ->setMerchantInfo(
                 (new MerchantInfo())
                     ->setCallBack($callback)
+                    ->setFallBack($fallback)
                     ->setMerchantSerialNumber($this->getMerchantSerialNumber())
             )
             ->setTransaction(
@@ -190,7 +191,7 @@ class Payment extends ApiBase implements PaymentInterface
         // Pass request object along with all data required by InitiatePayment
         // to make a call.
         $resource = new InitiatePayment($this->app, $this->getSubscriptionKey(), $request);
-        $resource->setPath(str_replace('Ecomm', $this->customPath, $resource->getPath()));
+        $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
         /** @var \zaporylie\Vipps\Model\Payment\ResponseInitiatePayment $response */
         $response = $resource->call();
         return $response;
@@ -218,7 +219,7 @@ class Payment extends ApiBase implements PaymentInterface
         }
         // Create a resource.
         $resource = new RefundPayment($this->app, $this->getSubscriptionKey(), $order_id, $request);
-        $resource->setPath(str_replace('Ecomm', $this->customPath, $resource->getPath()));
+        $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
         /** @var \zaporylie\Vipps\Model\Payment\ResponseRefundPayment $response */
         $response = $resource->call();
         return $response;

--- a/src/Api/PaymentInterface.php
+++ b/src/Api/PaymentInterface.php
@@ -47,11 +47,12 @@ interface PaymentInterface
      * @param int $amount
      * @param string $text
      * @param string $callback
+     * @param string $fallback
      * @param null $refOrderID
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseInitiatePayment
      */
-    public function initiatePayment($order_id, $mobile_number, $amount, $text, $callback, $refOrderID = null);
+    public function initiatePayment($order_id, $mobile_number, $amount, $text, $callback, $fallback, $refOrderID = null);
 
     /**
      * @param string $order_id

--- a/src/Model/Payment/MerchantInfo.php
+++ b/src/Model/Payment/MerchantInfo.php
@@ -22,7 +22,19 @@ class MerchantInfo
      * @var string
      * @Serializer\Type("string")
      */
-    protected $callBack;
+    protected $callbackPrefix;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $fallBack;
+
+    /**
+     * @var string
+     * @Serializer\Type("bool")
+     */
+    protected $isApp = false;
 
     /**
      * Gets merchantSerialNumber value.
@@ -54,11 +66,11 @@ class MerchantInfo
      */
     public function getCallBack()
     {
-        return $this->callBack;
+        return $this->callbackPrefix;
     }
 
     /**
-     * Sets callBack variable.
+     * Sets callbackPrefix variable.
      *
      * @param string $callBack
      *
@@ -66,7 +78,30 @@ class MerchantInfo
      */
     public function setCallBack($callBack)
     {
-        $this->callBack = $callBack;
+        $this->callbackPrefix = $callBack;
+        return $this;
+    }
+
+    /**
+     * Gets fallBack value.
+     *
+     * @return string
+     */
+    public function getFallBack()
+    {
+        return $this->fallBack;
+    }
+
+    /**
+     * Sets fallBack variable.
+     *
+     * @param string $fallBack
+     *
+     * @return $this
+     */
+    public function setFallBack($fallBack)
+    {
+        $this->fallBack = $fallBack;
         return $this;
     }
 }

--- a/src/Model/Payment/ResponseInitiatePayment.php
+++ b/src/Model/Payment/ResponseInitiatePayment.php
@@ -20,15 +20,9 @@ class ResponseInitiatePayment
 
     /**
      * @var string
-     * @Serializer\Type("string")
+     * @Serializer\type("string")
      */
-    protected $merchantSerialNumber;
-
-    /**
-     * @var \zaporylie\Vipps\Model\Payment\TransactionInfo
-     * @Serializer\Type("zaporylie\Vipps\Model\Payment\TransactionInfo")
-     */
-    protected $transactionInfo;
+    protected $url;
 
     /**
      * Gets orderId value.
@@ -41,22 +35,12 @@ class ResponseInitiatePayment
     }
 
     /**
-     * Gets merchantSerialNumber value.
+     * Gets URL  value.
      *
      * @return string
      */
-    public function getMerchantSerialNumber()
+    public function getURL()
     {
-        return $this->merchantSerialNumber;
-    }
-
-    /**
-     * Gets transactionInfo value.
-     *
-     * @return \zaporylie\Vipps\Model\Payment\TransactionInfo
-     */
-    public function getTransactionInfo()
-    {
-        return $this->transactionInfo;
+        return $this->url;
     }
 }

--- a/src/Model/Payment/TransactionInfo.php
+++ b/src/Model/Payment/TransactionInfo.php
@@ -40,7 +40,7 @@ class TransactionInfo
      * @var string
      * @Serializer\Type("string")
      */
-    protected $message;
+    protected $transactionText;
 
     /**
      * Gets amount value.
@@ -93,9 +93,9 @@ class TransactionInfo
      *
      * @return string
      */
-    public function getMessage()
+    public function getTransactionText()
     {
-        return $this->message;
+        return $this->transactionText;
     }
 
     /**
@@ -105,9 +105,9 @@ class TransactionInfo
      *
      * @return $this
      */
-    public function setMessage($message)
+    public function setTransactionText($message)
     {
-        $this->message = $message;
+        $this->transactionText = $message;
         return $this;
     }
 

--- a/src/Model/Payment/TransactionLog.php
+++ b/src/Model/Payment/TransactionLog.php
@@ -20,9 +20,9 @@ class TransactionLog
 
     /**
      * @var string
-     * @Serializer\Type("string")
+     * @Serializer\Type("bool")
      */
-    protected $operation;
+    protected $operationSuccess;
 
     /**
      * @var int
@@ -78,7 +78,7 @@ class TransactionLog
      */
     public function getOperation()
     {
-        return $this->operation;
+        return $this->operationSuccess;
     }
 
     /**
@@ -90,7 +90,7 @@ class TransactionLog
      */
     public function setOperation($operation)
     {
-        $this->operation = $operation;
+        $this->operationSuccess = $operation;
         return $this;
     }
 

--- a/src/Resource/Payment/CancelPayment.php
+++ b/src/Resource/Payment/CancelPayment.php
@@ -23,7 +23,7 @@ class CancelPayment extends PaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/Ecomm/v1/payments/{id}/cancel';
+    protected $path = '/ecomm/v2/payments/{id}/cancel';
 
     /**
      * InitiatePayment constructor.

--- a/src/Resource/Payment/CapturePayment.php
+++ b/src/Resource/Payment/CapturePayment.php
@@ -23,7 +23,7 @@ class CapturePayment extends PaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/Ecomm/v1/payments/{id}/capture';
+    protected $path = '/ecomm/v2/payments/{id}/capture';
 
     /**
      * InitiatePayment constructor.

--- a/src/Resource/Payment/GetOrderStatus.php
+++ b/src/Resource/Payment/GetOrderStatus.php
@@ -17,21 +17,19 @@ class GetOrderStatus extends PaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/Ecomm/v1/payments/{id}/serialNumber/{merchantSerialNumber}/status';
+    protected $path = '/ecomm/v2/payments/{id}/status';
 
     /**
      * InitiatePayment constructor.
      *
      * @param \zaporylie\Vipps\VippsInterface $vipps
      * @param string $subscription_key
-     * @param string $merchant_serial_number
      * @param string $order_id
      */
-    public function __construct(VippsInterface $vipps, $subscription_key, $merchant_serial_number, $order_id)
+    public function __construct(VippsInterface $vipps, $subscription_key, $order_id)
     {
         parent::__construct($vipps, $subscription_key);
         $this->id = $order_id;
-        $this->path = str_replace('{merchantSerialNumber}', $merchant_serial_number, $this->path);
     }
 
     /**

--- a/src/Resource/Payment/GetPaymentDetails.php
+++ b/src/Resource/Payment/GetPaymentDetails.php
@@ -17,21 +17,19 @@ class GetPaymentDetails extends PaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/Ecomm/v1/payments/{id}/serialNumber/{merchantSerialNumber}/details';
+    protected $path = '/ecomm/v2/payments/{id}/details';
 
     /**
      * InitiatePayment constructor.
      *
      * @param \zaporylie\Vipps\VippsInterface $vipps
      * @param string $subscription_key
-     * @param string $merchant_serial_number
      * @param string $order_id
      */
-    public function __construct(VippsInterface $vipps, $subscription_key, $merchant_serial_number, $order_id)
+    public function __construct(VippsInterface $vipps, $subscription_key, $order_id)
     {
         parent::__construct($vipps, $subscription_key);
         $this->id = $order_id;
-        $this->path = str_replace('{merchantSerialNumber}', $merchant_serial_number, $this->path);
     }
 
     /**

--- a/src/Resource/Payment/InitiatePayment.php
+++ b/src/Resource/Payment/InitiatePayment.php
@@ -23,7 +23,7 @@ class InitiatePayment extends PaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/Ecomm/v1/payments';
+    protected $path = '/ecomm/v2/payments';
 
     /**
      * InitiatePayment constructor.

--- a/src/Resource/Payment/PaymentResourceBase.php
+++ b/src/Resource/Payment/PaymentResourceBase.php
@@ -40,13 +40,5 @@ abstract class PaymentResourceBase extends AuthorizedResourceBase
         // Timestamp is equal to current DateTime.
         $this->headers['X-TimeStamp'] = (new \DateTime())->format(\DateTime::ISO8601);
 
-        // Autodiscover X-Source-Address from env.
-        $this->headers['X-Source-Address'] = getenv('HTTP_CLIENT_IP')
-            ?:getenv('HTTP_X_FORWARDED_FOR')
-            ?:getenv('HTTP_X_FORWARDED')
-            ?:getenv('HTTP_FORWARDED_FOR')
-            ?:getenv('HTTP_FORWARDED')
-            ?:getenv('REMOTE_ADDR')
-            ?:gethostname();
     }
 }

--- a/src/Resource/Payment/PaymentResourceBase.php
+++ b/src/Resource/Payment/PaymentResourceBase.php
@@ -31,9 +31,6 @@ abstract class PaymentResourceBase extends AuthorizedResourceBase
         // Content type for all requests must be set.
         $this->headers['Content-Type'] = 'application/json';
 
-        // Client ID must be set in X-App-Id header.
-        $this->headers['X-App-Id'] = $this->app->getClient()->getClientId();
-
         // By default RequestID is different for each Resource object.
         $this->headers['X-Request-Id'] = RequestIdFactory::generate();
 

--- a/src/Resource/Payment/RefundPayment.php
+++ b/src/Resource/Payment/RefundPayment.php
@@ -23,7 +23,7 @@ class RefundPayment extends PaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/Ecomm/v1/payments/{id}/refund';
+    protected $path = '/ecomm/v2/payments/{id}/refund';
 
     /**
      * InitiatePayment constructor.

--- a/src/Resource/PaymentsInterface.php
+++ b/src/Resource/PaymentsInterface.php
@@ -34,11 +34,13 @@ interface PaymentsInterface extends ResourceInterface
      *   Additional transaction text.
      * @param string $callback
      *   Callback absolute Url.
+     * @param string $fallback
+     *   Fallback absolute Url.
      * @param null $refOrderID
      *   (optional) Reference to previous order.
      * @return $this
      */
-    public function create($mobileNumber, $amount, $text, $callback, $refOrderID = null);
+    public function create($mobileNumber, $amount, $text, $callback, $fallback, $refOrderID = null);
 
     /**
      * Cancel payment.

--- a/src/Vipps.php
+++ b/src/Vipps.php
@@ -48,7 +48,7 @@ class Vipps implements VippsInterface
      *
      * @return \zaporylie\Vipps\Api\Payment
      */
-    public function payment($subscription_key, $merchant_serial_number, $custom_path = 'Ecomm')
+    public function payment($subscription_key, $merchant_serial_number, $custom_path = 'ecomm')
     {
         return new Payment($this, $subscription_key, $merchant_serial_number, $custom_path);
     }

--- a/test/Integration/Api/PaymentsTest.php
+++ b/test/Integration/Api/PaymentsTest.php
@@ -39,15 +39,8 @@ class PaymentsTest extends IntegrationTestBase
     {
         $this->mockResponse(parent::getResponse([
             'orderId' => 'test_order_id',
-            'merchantSerialNumber' => $this->merchantSerialNumber,
-            'transactionInfo' => [
-                'transactionId' => 'test_transaction_id',
-                'amount' => '1200',
-                'status' => 'test_status',
-                'timeStamp' => '2017-07-31T15:07:37.100Z',
-                'message' => 'test_message',
-            ]
-        ]));
+            'url' => 'https://www.example.com/vipps'
+    ]));
 
         // Do request.
         $response = $this->api->initiatePayment(
@@ -55,20 +48,13 @@ class PaymentsTest extends IntegrationTestBase
             '98765432',
             1200,
             'test_text',
-            'https://www.example.com'
+            'https://www.example.com/callback',
+            'https://www.example.com/fallback'
         );
 
         // Assert response.
         $this->assertEquals('test_order_id', $response->getOrderId());
-        $this->assertEquals($this->merchantSerialNumber, $response->getMerchantSerialNumber());
-        $this->assertEquals('test_transaction_id', $response->getTransactionInfo()->getTransactionId());
-        $this->assertEquals(1200, $response->getTransactionInfo()->getAmount());
-        $this->assertEquals('test_status', $response->getTransactionInfo()->getStatus());
-        $this->assertEquals(
-            '2017-07-31T15:07:37',
-            $response->getTransactionInfo()->getTimeStamp()->format('Y-m-d\TH:i:s')
-        );
-        $this->assertEquals('test_message', $response->getTransactionInfo()->getMessage());
+        $this->assertEquals('https://www.example.com/vipps', $response->getURL());
     }
 
     /**
@@ -78,7 +64,7 @@ class PaymentsTest extends IntegrationTestBase
     {
         $this->mockResponse(parent::getErrorResponse());
         $this->expectException(VippsException::class);
-        $this->api->initiatePayment('test_client_secret', '98765432', 1200, 'test_text', 'http://www.example.com');
+        $this->api->initiatePayment('test_client_secret', '98765432', 1200, 'test_text', 'http://www.example.com/callback', 'https://www.example.com/fallback');
     }
 
     /**
@@ -97,10 +83,10 @@ class PaymentsTest extends IntegrationTestBase
             ],
             'transactionInfo' => [
                 'amount' => 1200,
-                'message' => 'test_message',
                 'timeStamp' => '2017-07-31T15:07:37.100Z',
                 'status' => 'test_status',
                 'transactionId' => 'test_transaction_id',
+                'transactionText' => 'test_transaction_text'
             ],
         ]));
 
@@ -118,7 +104,7 @@ class PaymentsTest extends IntegrationTestBase
         $this->assertEquals(12, $response->getTransactionSummary()->getRefundedAmount());
         $this->assertEquals(13, $response->getTransactionSummary()->getRemainingAmountToRefund());
         $this->assertEquals(1200, $response->getTransactionInfo()->getAmount());
-        $this->assertEquals('test_message', $response->getTransactionInfo()->getMessage());
+        $this->assertEquals('test_transaction_text', $response->getTransactionInfo()->getTransactionText());
         $this->assertEquals(
             '2017-07-31T15:07:37',
             $response->getTransactionInfo()->getTimeStamp()->format('Y-m-d\TH:i:s')
@@ -144,10 +130,10 @@ class PaymentsTest extends IntegrationTestBase
             ],
             'transactionInfo' => [
                 'amount' => 1200,
-                'message' => 'test_message',
                 'timeStamp' => '2017-07-31T15:07:37.100Z',
                 'status' => 'test_status',
                 'transactionId' => 'test_transaction_id',
+                'transactionText' => 'test_transaction_text'
             ],
         ]));
 
@@ -164,7 +150,7 @@ class PaymentsTest extends IntegrationTestBase
         $this->assertEquals(12, $response->getTransactionSummary()->getRefundedAmount());
         $this->assertEquals(13, $response->getTransactionSummary()->getRemainingAmountToRefund());
         $this->assertEquals(1200, $response->getTransactionInfo()->getAmount());
-        $this->assertEquals('test_message', $response->getTransactionInfo()->getMessage());
+        $this->assertEquals('test_transaction_text', $response->getTransactionInfo()->getTransactionText());
         $this->assertEquals(
             '2017-07-31T15:07:37',
             $response->getTransactionInfo()->getTimeStamp()->format('Y-m-d\TH:i:s')
@@ -190,7 +176,7 @@ class PaymentsTest extends IntegrationTestBase
             ],
             'transactionInfo' => [
                 'amount' => 1200,
-                'message' => 'test_message',
+                'transactionText' => 'test_transaction_text',
                 'timeStamp' => '2017-07-31T15:07:37.100Z',
                 'status' => 'test_status',
                 'transactionId' => 'test_transaction_id',
@@ -211,7 +197,7 @@ class PaymentsTest extends IntegrationTestBase
         $this->assertEquals(12, $response->getTransactionSummary()->getRefundedAmount());
         $this->assertEquals(13, $response->getTransactionSummary()->getRemainingAmountToRefund());
         $this->assertEquals(1200, $response->getTransactionInfo()->getAmount());
-        $this->assertEquals('test_message', $response->getTransactionInfo()->getMessage());
+        $this->assertEquals('test_transaction_text', $response->getTransactionInfo()->getTransactionText());
         $this->assertEquals(
             '2017-07-31T15:07:37',
             $response->getTransactionInfo()->getTimeStamp()->format('Y-m-d\TH:i:s')
@@ -231,7 +217,6 @@ class PaymentsTest extends IntegrationTestBase
             'orderId' => 'test_order_id',
             'transactionInfo' => [
                 'amount' => 1200,
-                'message' => 'test_message',
                 'timeStamp' => '2017-07-31T15:07:37.100Z',
                 'status' => 'test_status',
                 'transactionId' => 'test_transaction_id',
@@ -246,7 +231,6 @@ class PaymentsTest extends IntegrationTestBase
         // Assert response.
         $this->assertEquals('test_order_id', $response->getOrderId());
         $this->assertEquals(1200, $response->getTransactionInfo()->getAmount());
-        $this->assertEquals('test_message', $response->getTransactionInfo()->getMessage());
         $this->assertEquals(
             '2017-07-31T15:07:37',
             $response->getTransactionInfo()->getTimeStamp()->format('Y-m-d\TH:i:s')
@@ -274,7 +258,7 @@ class PaymentsTest extends IntegrationTestBase
                 'amount' => 1200,
                 'transactionText' => 'test_transaction_text',
                 'timeStamp' => '2017-07-31T15:07:37.100Z',
-                'operation' => 'test_operation',
+                'operationSuccess' => true,
                 'transactionId' => 'test_transaction_id',
                 'requestId' => 'test_request_id',
             ]],
@@ -297,7 +281,7 @@ class PaymentsTest extends IntegrationTestBase
             '2017-07-31T15:07:37',
             $response->getTransactionLogHistory()[0]->getTimeStamp()->format('Y-m-d\TH:i:s')
         );
-        $this->assertEquals('test_operation', $response->getTransactionLogHistory()[0]->getOperation());
+        $this->assertEquals(true, $response->getTransactionLogHistory()[0]->getOperation());
         $this->assertEquals('test_transaction_id', $response->getTransactionLogHistory()[0]->getTransactionId());
         $this->assertEquals('test_request_id', $response->getTransactionLogHistory()[0]->getRequestId());
     }

--- a/test/Unit/Model/Payment/MerchantInfoTest.php
+++ b/test/Unit/Model/Payment/MerchantInfoTest.php
@@ -21,7 +21,8 @@ class MerchantInfoTest extends ModelTestBase
         parent::setUp();
         $this->model = (new MerchantInfo())
             ->setMerchantSerialNumber(12345)
-            ->setCallBack('http://example.com');
+            ->setCallBack('http://example.com/callback')
+            ->setFallBack('http://example.com/fallback');
     }
 
     /**
@@ -46,7 +47,7 @@ class MerchantInfoTest extends ModelTestBase
      */
     public function testGetCallBack()
     {
-        $this->assertEquals('http://example.com', $this->model->getCallBack());
+        $this->assertEquals('http://example.com/callback', $this->model->getCallBack());
     }
 
     /**
@@ -56,5 +57,22 @@ class MerchantInfoTest extends ModelTestBase
     {
         $this->assertInstanceOf(MerchantInfo::class, $this->model->setCallBack('http://test.example.com'));
         $this->assertEquals('http://test.example.com', $this->model->getCallBack());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\Payment\MerchantInfo::getFallBack()
+     */
+    public function testGetFallBack()
+    {
+        $this->assertEquals('http://example.com/fallback', $this->model->getFallBack());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\Payment\MerchantInfo::setFallBack()
+     */
+    public function testSetFallBack()
+    {
+        $this->assertInstanceOf(MerchantInfo::class, $this->model->setFallBack('http://fallback.example.com'));
+        $this->assertEquals('http://fallback.example.com', $this->model->getFallBack());
     }
 }

--- a/test/Unit/Model/Payment/ResponseInitiatePaymentTest.php
+++ b/test/Unit/Model/Payment/ResponseInitiatePaymentTest.php
@@ -27,8 +27,7 @@ class ResponseInitiatePaymentTest extends ModelTestBase
         $this->model = $resource->getSerializer()->deserialize(
             json_encode((object) [
                 'orderId' => 'test_order_id',
-                'merchantSerialNumber' => 'test_merchant_serial_number',
-                'transactionInfo' => [],
+                'url' => 'https://www.example.com/vipps',
             ]),
             ResponseInitiatePayment::class,
             'json'
@@ -44,18 +43,10 @@ class ResponseInitiatePaymentTest extends ModelTestBase
     }
 
     /**
-     * @covers \zaporylie\Vipps\Model\Payment\ResponseInitiatePayment::getMerchantSerialNumber()
+     * @covers \zaporylie\Vipps\Model\Payment\ResponseInitiatePayment::getURL()
      */
-    public function testMerchantSerialNumber()
+    public function testURL()
     {
-        $this->assertEquals('test_merchant_serial_number', $this->model->getMerchantSerialNumber());
-    }
-
-    /**
-     * @covers \zaporylie\Vipps\Model\Payment\ResponseInitiatePayment::getTransactionInfo()
-     */
-    public function testTransactionInfo()
-    {
-        $this->assertInstanceOf(TransactionInfo::class, $this->model->getTransactionInfo());
+        $this->assertEquals('https://www.example.com/vipps', $this->model->getURL());
     }
 }

--- a/test/Unit/Model/Payment/TransactionInfoTest.php
+++ b/test/Unit/Model/Payment/TransactionInfoTest.php
@@ -67,13 +67,13 @@ class TransactionInfoTest extends ModelTestBase
     }
 
     /**
-     * @covers \zaporylie\Vipps\Model\Payment\TransactionInfo::getMessage()
-     * @covers \zaporylie\Vipps\Model\Payment\TransactionInfo::setMessage()
+     * @covers \zaporylie\Vipps\Model\Payment\TransactionInfo::getTransactionText()
+     * @covers \zaporylie\Vipps\Model\Payment\TransactionInfo::setTransactionText()
      */
-    public function testMessage()
+    public function testTransactionText()
     {
-        $this->assertNull($this->model->getMessage());
-        $this->assertInstanceOf(TransactionInfo::class, $this->model->setMessage('test_message'));
-        $this->assertEquals('test_message', $this->model->getMessage());
+        $this->assertNull($this->model->getTransactionText());
+        $this->assertInstanceOf(TransactionInfo::class, $this->model->setTransactionText('test_message'));
+        $this->assertEquals('test_message', $this->model->getTransactionText());
     }
 }

--- a/test/Unit/Resource/Payment/CancelPaymentTest.php
+++ b/test/Unit/Resource/Payment/CancelPaymentTest.php
@@ -59,9 +59,9 @@ class CancelPaymentTest extends PaymentResourceBaseTestBase
      */
     public function testPath()
     {
-        $this->assertEquals('/Ecomm/v1/payments/test_order_id/cancel', $this->resource->getPath());
+        $this->assertEquals('/ecomm/v2/payments/test_order_id/cancel', $this->resource->getPath());
         $this->getStringReplace();
-        $this->assertEquals('/test_path/v1/payments/test_order_id/cancel', $this->resource->getPath());
+        $this->assertEquals('/test_path/v2/payments/test_order_id/cancel', $this->resource->getPath());
     }
 
     /**

--- a/test/Unit/Resource/Payment/CapturePaymentTest.php
+++ b/test/Unit/Resource/Payment/CapturePaymentTest.php
@@ -59,9 +59,9 @@ class CapturePaymentTest extends PaymentResourceBaseTestBase
      */
     public function testPath()
     {
-        $this->assertEquals('/Ecomm/v1/payments/test_order_id/capture', $this->resource->getPath());
+        $this->assertEquals('/ecomm/v2/payments/test_order_id/capture', $this->resource->getPath());
         $this->getStringReplace();
-        $this->assertEquals('/test_path/v1/payments/test_order_id/capture', $this->resource->getPath());
+        $this->assertEquals('/test_path/v2/payments/test_order_id/capture', $this->resource->getPath());
     }
 
     /**

--- a/test/Unit/Resource/Payment/GetOrderStatusTest.php
+++ b/test/Unit/Resource/Payment/GetOrderStatusTest.php
@@ -26,7 +26,6 @@ class GetOrderStatusTest extends PaymentResourceBaseTestBase
             ->setConstructorArgs([
                 $this->vipps,
                 'test_subscription_key',
-                'test_merchant_serial_number',
                 'test_order_id'
             ])
             ->disallowMockingUnknownTypes()
@@ -62,12 +61,12 @@ class GetOrderStatusTest extends PaymentResourceBaseTestBase
     public function testPath()
     {
         $this->assertEquals(
-            '/Ecomm/v1/payments/test_order_id/serialNumber/test_merchant_serial_number/status',
+            '/ecomm/v2/payments/test_order_id/status',
             $this->resource->getPath()
         );
         $this->getStringReplace();
         $this->assertEquals(
-            '/test_path/v1/payments/test_order_id/serialNumber/test_merchant_serial_number/status',
+            '/test_path/v2/payments/test_order_id/status',
             $this->resource->getPath()
         );
     }

--- a/test/Unit/Resource/Payment/GetPaymentDetailsTest.php
+++ b/test/Unit/Resource/Payment/GetPaymentDetailsTest.php
@@ -26,7 +26,6 @@ class GetPaymentDetailsTest extends PaymentResourceBaseTestBase
             ->setConstructorArgs([
                 $this->vipps,
                 'test_subscription_key',
-                'test_merchant_serial_number',
                 'test_order_id'
             ])
             ->disallowMockingUnknownTypes()
@@ -62,12 +61,12 @@ class GetPaymentDetailsTest extends PaymentResourceBaseTestBase
     public function testPath()
     {
         $this->assertEquals(
-            '/Ecomm/v1/payments/test_order_id/serialNumber/test_merchant_serial_number/details',
+            '/ecomm/v2/payments/test_order_id/details',
             $this->resource->getPath()
         );
         $this->getStringReplace();
         $this->assertEquals(
-            '/test_path/v1/payments/test_order_id/serialNumber/test_merchant_serial_number/details',
+            '/test_path/v2/payments/test_order_id/details',
             $this->resource->getPath()
         );
     }

--- a/test/Unit/Resource/Payment/InitiatePaymentTest.php
+++ b/test/Unit/Resource/Payment/InitiatePaymentTest.php
@@ -59,9 +59,9 @@ class InitiatePaymentTest extends PaymentResourceBaseTestBase
      */
     public function testPath()
     {
-        $this->assertEquals('/Ecomm/v1/payments', $this->resource->getPath());
+        $this->assertEquals('/ecomm/v2/payments', $this->resource->getPath());
         $this->getStringReplace();
-        $this->assertEquals('/test_path/v1/payments', $this->resource->getPath());
+        $this->assertEquals('/test_path/v2/payments', $this->resource->getPath());
     }
 
     /**

--- a/test/Unit/Resource/Payment/PaymentResourceBaseTestBase.php
+++ b/test/Unit/Resource/Payment/PaymentResourceBaseTestBase.php
@@ -19,8 +19,8 @@ class PaymentResourceBaseTestBase extends ResourceTestBase
     public function testHeaders()
     {
         $headers = $this->resource->getHeaders();
-        $this->assertArrayHasKey('X-App-Id', $headers);
-        $this->assertEquals('test_client_id', $headers['X-App-Id']);
+        $this->assertArrayHasKey('Authorization', $headers);
+        $this->assertEquals('test_token_type test_access_token', $headers['Authorization']);
         $this->assertArrayHasKey('Content-Type', $headers);
         $this->assertEquals('application/json', $headers['Content-Type']);
         $this->assertArrayHasKey('X-TimeStamp', $headers);

--- a/test/Unit/Resource/Payment/PaymentResourceBaseTestBase.php
+++ b/test/Unit/Resource/Payment/PaymentResourceBaseTestBase.php
@@ -23,8 +23,6 @@ class PaymentResourceBaseTestBase extends ResourceTestBase
         $this->assertEquals('test_client_id', $headers['X-App-Id']);
         $this->assertArrayHasKey('Content-Type', $headers);
         $this->assertEquals('application/json', $headers['Content-Type']);
-        $this->assertArrayHasKey('X-Source-Address', $headers);
-        $this->assertNotEmpty($headers['X-Source-Address']);
         $this->assertArrayHasKey('X-TimeStamp', $headers);
         $this->assertNotEmpty($headers['X-TimeStamp']);
         $this->assertArrayHasKey('X-Request-Id', $headers);
@@ -36,6 +34,6 @@ class PaymentResourceBaseTestBase extends ResourceTestBase
      */
     protected function getStringReplace()
     {
-        $this->resource->setPath(str_replace('Ecomm', 'test_path', $this->resource->getPath()));
+        $this->resource->setPath(str_replace('ecomm', 'test_path', $this->resource->getPath()));
     }
 }

--- a/test/Unit/Resource/Payment/RefundPaymentTest.php
+++ b/test/Unit/Resource/Payment/RefundPaymentTest.php
@@ -59,9 +59,9 @@ class RefundPaymentTest extends PaymentResourceBaseTestBase
      */
     public function testPath()
     {
-        $this->assertEquals('/Ecomm/v1/payments/test_order_id/refund', $this->resource->getPath());
+        $this->assertEquals('/ecomm/v2/payments/test_order_id/refund', $this->resource->getPath());
         $this->getStringReplace();
-        $this->assertEquals('/test_path/v1/payments/test_order_id/refund', $this->resource->getPath());
+        $this->assertEquals('/test_path/v2/payments/test_order_id/refund', $this->resource->getPath());
     }
 
     /**


### PR DESCRIPTION
Initial support for V2 of the vipps API. Should probably not be merged against the 1.x branch. 

Warning: Not testet very thoroughly. 