### PR TITLE
Mark GetOrderStatus resource as deprecated as per Vipps notice

### DIFF
--- a/src/Api/PaymentInterface.php
+++ b/src/Api/PaymentInterface.php
@@ -31,6 +31,9 @@ interface PaymentInterface
      * @param string $order_id
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseGetOrderStatus
+     *
+     * @deprecated Get order status was deprecated and can be removed in version 3.0.
+     * @see \zaporylie\Vipps\Resource\Payment\GetOrderStatus
      */
     public function getOrderStatus($order_id);
 

--- a/src/Resource/Payment/GetOrderStatus.php
+++ b/src/Resource/Payment/GetOrderStatus.php
@@ -6,6 +6,14 @@ use zaporylie\Vipps\Model\Payment\ResponseGetOrderStatus;
 use zaporylie\Vipps\Resource\HttpMethod;
 use zaporylie\Vipps\VippsInterface;
 
+/**
+ * Class GetOrderStatus
+ * @package zaporylie\Vipps\Resource\Payment
+ * @deprecated
+ *   This API call allows the merchant to get the status of the last payment transaction.
+ *   Primarily use of this service is meant for inApp where simple response to check order
+ *   status is preferred.
+ */
 class GetOrderStatus extends PaymentResourceBase
 {
 


### PR DESCRIPTION
Vipps marked /ecomm/v2/payments/{orderId}/status endpoint as deprecated - see https://vippsas.github.io/vipps-ecom-api/#/