### PR TITLE
Add basic support for request ID in capturePayment

### DIFF
--- a/src/Api/Payment.php
+++ b/src/Api/Payment.php
@@ -103,7 +103,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function capturePayment($order_id, $text, $amount = 0)
+    public function capturePayment($order_id, $text, $amount = 0, $request_id = NULL)
     {
         // Build request object from data passed to method.
         $request = (new RequestCapturePayment())
@@ -120,6 +120,7 @@ class Payment extends ApiBase implements PaymentInterface
             $request->getTransaction()->setAmount($amount);
         }
         $resource = new CapturePayment($this->app, $this->getSubscriptionKey(), $order_id, $request);
+        $resource->setRequestID($request_id);
         $resource->setPath(str_replace('ecomm', $this->customPath, $resource->getPath()));
         /** @var \zaporylie\Vipps\Model\Payment\ResponseCapturePayment $response */
         $response = $resource->call();

--- a/src/Api/Payment.php
+++ b/src/Api/Payment.php
@@ -103,7 +103,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function capturePayment($order_id, $text, $amount = 0, $request_id = NULL)
+    public function capturePayment($order_id, $text, $amount = 0, $request_id = null)
     {
         // Build request object from data passed to method.
         $request = (new RequestCapturePayment())

--- a/src/Api/PaymentInterface.php
+++ b/src/Api/PaymentInterface.php
@@ -26,7 +26,7 @@ interface PaymentInterface
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseCapturePayment
      */
-    public function capturePayment($order_id, $text, $amount = 0, $request_id = NULL);
+    public function capturePayment($order_id, $text, $amount = 0, $request_id = null);
 
     /**
      * @param string $order_id

--- a/src/Api/PaymentInterface.php
+++ b/src/Api/PaymentInterface.php
@@ -22,10 +22,11 @@ interface PaymentInterface
      * @param string $order_id
      * @param string $text
      * @param int $amount
+     * @param string $request_id
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseCapturePayment
      */
-    public function capturePayment($order_id, $text, $amount = 0);
+    public function capturePayment($order_id, $text, $amount = 0, $request_id = NULL);
 
     /**
      * @param string $order_id

--- a/src/Resource/Payment/PaymentResourceBase.php
+++ b/src/Resource/Payment/PaymentResourceBase.php
@@ -32,9 +32,22 @@ abstract class PaymentResourceBase extends AuthorizedResourceBase
         $this->headers['Content-Type'] = 'application/json';
 
         // By default RequestID is different for each Resource object.
-        $this->headers['X-Request-Id'] = RequestIdFactory::generate();
+        $this->setRequestID(RequestIdFactory::generate());
 
         // Timestamp is equal to current DateTime.
         $this->headers['X-TimeStamp'] = (new \DateTime())->format(\DateTime::ISO8601);
     }
+
+    /**
+     * set specific request ID
+     * @param string $request_id
+     * @return $this
+     */
+    public function setRequestID($request_id) {
+        if (!empty($request_id)) {
+            $this->headers['X-Request-Id'] = $request_id;
+        }
+        return $this;
+    }
+
 }

--- a/src/Resource/Payment/PaymentResourceBase.php
+++ b/src/Resource/Payment/PaymentResourceBase.php
@@ -43,11 +43,11 @@ abstract class PaymentResourceBase extends AuthorizedResourceBase
      * @param string $request_id
      * @return $this
      */
-    public function setRequestID($request_id) {
+    public function setRequestID($request_id)
+    {
         if (!empty($request_id)) {
             $this->headers['X-Request-Id'] = $request_id;
         }
         return $this;
     }
-
 }


### PR DESCRIPTION
Vipps supports idempotency of requests by means of a `X-Request-Id` header.
Added basic support for request-id in the `capturePayment` method to be able nicely handle repeated captures on the same transaction.