### PR TITLE
Fix breaking typos in Recurring API

### DIFF
--- a/src/Model/RecurringPayment/Agreement.php
+++ b/src/Model/RecurringPayment/Agreement.php
@@ -14,7 +14,7 @@ class Agreement
 
     /**
      * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
-     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaingnRequest")
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
      */
     protected $campaign;
 

--- a/src/Model/RecurringPayment/RequestCreateAgreement.php
+++ b/src/Model/RecurringPayment/RequestCreateAgreement.php
@@ -13,7 +13,7 @@ class RequestCreateAgreement
 {
     /**
      * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
-     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaingnRequest")
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
      */
     protected $campaign;
 

--- a/src/Model/RecurringPayment/RequestUpdateAgreement.php
+++ b/src/Model/RecurringPayment/RequestUpdateAgreement.php
@@ -13,7 +13,7 @@ class RequestUpdateAgreement
 {
     /**
      * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
-     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaingnRequest")
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
      */
     protected $campaign;
 


### PR DESCRIPTION
Serializer annotations regarding "CampaignRequest" were typoed as "CampaingnRequest"