### PR TITLE
CampaignRequest: Change end datetime format and add getset

### DIFF
--- a/src/Model/RecurringPayment/CampaignRequest.php
+++ b/src/Model/RecurringPayment/CampaignRequest.php
@@ -27,7 +27,7 @@ class CampaignRequest
      * Get the value of end
      *
      * @return  \DateTimeInterface
-     */ 
+     */
     public function getEnd()
     {
         return $this->end;
@@ -39,7 +39,7 @@ class CampaignRequest
      * @param  \DateTimeInterface  $end
      *
      * @return  self
-     */ 
+     */
     public function setEnd(\DateTimeInterface $end)
     {
         $this->end = $end;
@@ -51,7 +51,7 @@ class CampaignRequest
      * Get the value of campaignPrice
      *
      * @return  int
-     */ 
+     */
     public function getCampaignPrice()
     {
         return $this->campaignPrice;
@@ -63,7 +63,7 @@ class CampaignRequest
      * @param  int  $campaignPrice
      *
      * @return  self
-     */ 
+     */
     public function setCampaignPrice(int $campaignPrice)
     {
         $this->campaignPrice = $campaignPrice;

--- a/src/Model/RecurringPayment/CampaignRequest.php
+++ b/src/Model/RecurringPayment/CampaignRequest.php
@@ -19,7 +19,55 @@ class CampaignRequest
 
     /**
      * @var \DateTimeInterface
-     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s.u\Z'>")
+     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s\Z'>")
      */
     protected $end;
+
+    /**
+     * Get the value of end
+     *
+     * @return  \DateTimeInterface
+     */ 
+    public function getEnd()
+    {
+        return $this->end;
+    }
+
+    /**
+     * Set the value of end
+     *
+     * @param  \DateTimeInterface  $end
+     *
+     * @return  self
+     */ 
+    public function setEnd(\DateTimeInterface $end)
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of campaignPrice
+     *
+     * @return  int
+     */ 
+    public function getCampaignPrice()
+    {
+        return $this->campaignPrice;
+    }
+
+    /**
+     * Set the value of campaignPrice
+     *
+     * @param  int  $campaignPrice
+     *
+     * @return  self
+     */ 
+    public function setCampaignPrice(int $campaignPrice)
+    {
+        $this->campaignPrice = $campaignPrice;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Since creating an agreement requires a CampaignRequest instance to be able to specify a campaign and i couldn't find any interface for CampaignRequest i added getters and setters to the class.
Also changed the date time formatting to match up with the rest of the package.
