### PR TITLE
Fix #38: Open up for php-http/httplug 2.0 to support Guzzle7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,14 @@
         "php": "^7.2 || ^8.0",
         "psr/http-message": "^1.0",
         "php-http/message": "^1.6",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^1.0 || ^2.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",
         "eloquent/enumeration": "^5.1",
         "jms/serializer": "^1.8 || ^3.0"
     },
     "require-dev": {
-        "php-http/guzzle6-adapter": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
         "phpunit/phpunit": ">=5 <9",
         "symfony/yaml": "^2.0",
         "symfony/filesystem": "^3.1",


### PR DESCRIPTION
I manually tested it with php-http/guzzle6-adapter (v2.0.2) and all seems working very well after the switch. Also successfully tested php-http/guzzle7-adapter (1.0.0)