### PR TITLE
Feat/recurring v3 support

### DIFF
--- a/src/Api/RecurringPayment.php
+++ b/src/Api/RecurringPayment.php
@@ -7,6 +7,7 @@ use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestRefundCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase;
+use zaporylie\Vipps\Model\RecurringPayment\v3\RequestCaptureCharge;
 use zaporylie\Vipps\Resource\RecurringPayment\CancelCharge;
 use zaporylie\Vipps\Resource\RecurringPayment\CaptureCharge;
 use zaporylie\Vipps\Resource\RecurringPayment\CreateAgreement;
@@ -152,9 +153,9 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritDoc}
      */
-    public function captureCharge($agreement_id, $charge_id)
+    public function captureCharge($agreement_id, $charge_id, RequestCaptureCharge $requestObject)
     {
-        $resource = new CaptureCharge($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id, $charge_id);
+        $resource = new CaptureCharge($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id, $charge_id, $requestObject);
         $response = $resource->call();
         return $response;
     }

--- a/src/Api/RecurringPayment.php
+++ b/src/Api/RecurringPayment.php
@@ -3,10 +3,10 @@
 namespace zaporylie\Vipps\Api;
 
 use zaporylie\Vipps\Exceptions\Api\InvalidArgumentException;
-use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestRefundCharge;
-use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase;
 use zaporylie\Vipps\Resource\RecurringPayment\CancelCharge;
 use zaporylie\Vipps\Resource\RecurringPayment\CaptureCharge;
 use zaporylie\Vipps\Resource\RecurringPayment\CreateAgreement;
@@ -33,6 +33,11 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     protected $merchantSerialNumber;
 
     /**
+     * @var int
+     */
+    protected $api_endpoint_version;
+
+    /**
      * Gets merchantSerialNumber value.
      *
      * @return string
@@ -46,30 +51,30 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     }
 
     /**
-     * Payment constructor.
-     *
-     * Payments API needs one extra param - merchant serial number.
+     * Recurring Payments constructor.
      *
      * @param \zaporylie\Vipps\VippsInterface $app
      * @param string $subscription_key
      * @param $merchant_serial_number
-     * @param $custom_path
+     * @param int $api_endpoint_version
      */
     public function __construct(
         VippsInterface $app,
         $subscription_key,
-        $merchant_serial_number
+        $merchant_serial_number,
+        $api_endpoint_version
     ) {
         parent::__construct($app, $subscription_key);
         $this->merchantSerialNumber = $merchant_serial_number;
+        $this->api_endpoint_version = $api_endpoint_version;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createAgreement(RequestCreateAgreement $request)
+    public function createAgreement(RequestCreateAgreementBase $request)
     {
-        $resource = new CreateAgreement($this->app, $this->getSubscriptionKey(), $request);
+        $resource = new CreateAgreement($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $request);
         $response = $resource->call();
         return $response;
     }
@@ -79,7 +84,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      */
     public function getAgreements()
     {
-        $resource = new GetAgreements($this->app, $this->getSubscriptionKey());
+        $resource = new GetAgreements($this->app, $this->api_endpoint_version, $this->getSubscriptionKey());
         $response = $resource->call();
         return $response;
     }
@@ -89,7 +94,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      */
     public function getAgreement($agreement_id)
     {
-        $resource = new GetAgreement($this->app, $this->getSubscriptionKey(), $agreement_id);
+        $resource = new GetAgreement($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id);
         $response = $resource->call();
         return $response;
     }
@@ -97,9 +102,9 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function updateAgreement($agreement_id, RequestUpdateAgreement $request)
+    public function updateAgreement($agreement_id, RequestUpdateAgreementBase $request)
     {
-        $resource = new UpdateAgreement($this->app, $this->getSubscriptionKey(), $agreement_id, $request);
+        $resource = new UpdateAgreement($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id, $request);
         $response = $resource->call();
         return $response;
     }
@@ -109,7 +114,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      */
     public function getCharges($agreement_id)
     {
-        $resource = new GetCharges($this->app, $this->getSubscriptionKey(), $agreement_id);
+        $resource = new GetCharges($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id);
         $response = $resource->call();
         return $response;
     }
@@ -119,7 +124,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      */
     public function getCharge($agreement_id, $charge_id)
     {
-        $resource = new GetCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $charge_id);
+        $resource = new GetCharge($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id, $charge_id);
         $response = $resource->call();
         return $response;
     }
@@ -129,7 +134,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      */
     public function createCharge($agreement_id, RequestCreateCharge $request)
     {
-        $resource = new CreateCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $request);
+        $resource = new CreateCharge($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id, $request);
         $response = $resource->call();
         return $response;
     }
@@ -139,7 +144,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      */
     public function cancelCharge($agreement_id, $charge_id)
     {
-        $resource = new CancelCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $charge_id);
+        $resource = new CancelCharge($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id, $charge_id);
         $response = $resource->call();
         return $response;
     }
@@ -149,7 +154,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      */
     public function captureCharge($agreement_id, $charge_id)
     {
-        $resource = new CaptureCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $charge_id);
+        $resource = new CaptureCharge($this->app, $this->api_endpoint_version, $this->getSubscriptionKey(), $agreement_id, $charge_id);
         $response = $resource->call();
         return $response;
     }
@@ -160,7 +165,8 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     public function refundCharge($agreement_id, $charge_id, RequestRefundCharge $requestObject)
     {
         $resource = new RefundCharge(
-            $this->app,
+            $this->app, 
+            $this->api_endpoint_version,
             $this->getSubscriptionKey(),
             $agreement_id,
             $charge_id,

--- a/src/Api/RecurringPaymentInterface.php
+++ b/src/Api/RecurringPaymentInterface.php
@@ -6,6 +6,7 @@ use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestRefundCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase;
+use zaporylie\Vipps\Model\RecurringPayment\v3\RequestCaptureCharge;
 
 /**
  * Interface PaymentInterface
@@ -77,7 +78,7 @@ interface RecurringPaymentInterface
      *
      * @return string
      */
-    public function captureCharge($agreement_id, $charge_id);
+    public function captureCharge($agreement_id, $charge_id, RequestCaptureCharge $requestObject);
 
     /**
      * @param string $agreement_id

--- a/src/Api/RecurringPaymentInterface.php
+++ b/src/Api/RecurringPaymentInterface.php
@@ -2,10 +2,10 @@
 
 namespace zaporylie\Vipps\Api;
 
-use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestRefundCharge;
-use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase;
 
 /**
  * Interface PaymentInterface
@@ -16,29 +16,29 @@ interface RecurringPaymentInterface
 {
 
     /**
-     * @param \zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement
+     * @param \zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase
      *
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseCreateAgreement
      */
-    public function createAgreement(RequestCreateAgreement $requestCreateAgreement);
+    public function createAgreement(RequestCreateAgreementBase $requestCreateAgreement);
 
     /**
-     * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement[]
+     * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreementBase[]
      */
     public function getAgreements();
 
     /**
-     * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement
+     * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreementBase
      */
     public function getAgreement($agreement_id);
 
     /**
      * @param $agreement_id
-     * @param \zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreement $request
+     * @param \zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase $request
      *
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseUpdateAgreement
      */
-    public function updateAgreement($agreement_id, RequestUpdateAgreement $request);
+    public function updateAgreement($agreement_id, RequestUpdateAgreementBase $request);
 
     /**
      * @param $agreement_id

--- a/src/Model/RecurringPayment/AgreementBase.php
+++ b/src/Model/RecurringPayment/AgreementBase.php
@@ -5,48 +5,17 @@ namespace zaporylie\Vipps\Model\RecurringPayment;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * Class ResponseGetAgreement
+ * Class AgreementBase
  *
  * @package Vipps\Model\RecurringPayment
  */
-class Agreement
+class AgreementBase
 {
-
-    /**
-     * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
-     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
-     */
-    protected $campaign;
-
-    /**
-     * @var string
-     * @Serializer\Type("string")
-     */
-    protected $currency;
-
     /**
      * @var string
      * @Serializer\Type("string")
      */
     protected $id;
-
-    /**
-     * @var string
-     * @Serializer\Type("string")
-     */
-    protected $interval;
-
-    /**
-     * @var int
-     * @Serializer\Type("integer")
-     */
-    protected $intervalCount;
-
-    /**
-     * @var int
-     * @Serializer\Type("integer")
-     */
-    protected $price;
 
     /**
      * @var string
@@ -97,26 +66,6 @@ class Agreement
     protected $tags;
 
     /**
-     * Gets campaign value.
-     *
-     * @return \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
-     */
-    public function getCampaign()
-    {
-        return $this->campaign;
-    }
-
-    /**
-     * Gets currency value.
-     *
-     * @return string
-     */
-    public function getCurrency()
-    {
-        return $this->currency;
-    }
-
-    /**
      * Gets id value.
      *
      * @return string
@@ -124,36 +73,6 @@ class Agreement
     public function getId()
     {
         return $this->id;
-    }
-
-    /**
-     * Gets interval value.
-     *
-     * @return string
-     */
-    public function getInterval()
-    {
-        return $this->interval;
-    }
-
-    /**
-     * Gets intervalCount value.
-     *
-     * @return int
-     */
-    public function getIntervalCount()
-    {
-        return $this->intervalCount;
-    }
-
-    /**
-     * Gets price value.
-     *
-     * @return int
-     */
-    public function getPrice()
-    {
-        return $this->price;
     }
 
     /**

--- a/src/Model/RecurringPayment/RequestCreateAgreementBase.php
+++ b/src/Model/RecurringPayment/RequestCreateAgreementBase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment;
+
+/**
+ * Class RequestCreateAgreementBase
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class RequestCreateAgreementBase
+{
+   
+}

--- a/src/Model/RecurringPayment/RequestCreateCharge.php
+++ b/src/Model/RecurringPayment/RequestCreateCharge.php
@@ -5,7 +5,7 @@ namespace zaporylie\Vipps\Model\RecurringPayment;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * Class ResponseGetAgreement
+ * Class RequestCreateCharge
  *
  * @package Vipps\Model\RecurringPayment
  */

--- a/src/Model/RecurringPayment/RequestCreateCharge.php
+++ b/src/Model/RecurringPayment/RequestCreateCharge.php
@@ -48,6 +48,12 @@ class RequestCreateCharge
     protected $orderId;
 
     /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $type;
+
+    /**
      * Sets amount variable.
      *
      * @param int $amount
@@ -122,6 +128,20 @@ class RequestCreateCharge
     public function setOrderId($orderId)
     {
         $this->orderId = $orderId;
+        return $this;
+    }
+
+    /**
+     * Set the value of type
+     *
+     * @param  string  $type
+     *
+     * @return  self
+     */ 
+    public function setType(string $type)
+    {
+        $this->type = $type;
+
         return $this;
     }
 }

--- a/src/Model/RecurringPayment/RequestCreateCharge.php
+++ b/src/Model/RecurringPayment/RequestCreateCharge.php
@@ -51,7 +51,7 @@ class RequestCreateCharge
      * @var string
      * @Serializer\Type("string")
      */
-    protected $type;
+    protected $transactionType;
 
     /**
      * Sets amount variable.
@@ -132,15 +132,15 @@ class RequestCreateCharge
     }
 
     /**
-     * Set the value of type
+     * Set the value of transactionType
      *
-     * @param  string  $type
+     * @param  string  $transactionType
      *
      * @return  self
      */ 
-    public function setType(string $type)
+    public function setTransactionType(string $transactionType)
     {
-        $this->type = $type;
+        $this->transactionType = $transactionType;
 
         return $this;
     }

--- a/src/Model/RecurringPayment/RequestUpdateAgreementBase.php
+++ b/src/Model/RecurringPayment/RequestUpdateAgreementBase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment;
+
+/**
+ * Class RequestUpdateAgreementBase
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class RequestUpdateAgreementBase
+{
+   
+}

--- a/src/Model/RecurringPayment/ResponseGetAgreementBase.php
+++ b/src/Model/RecurringPayment/ResponseGetAgreementBase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class ResponseGetAgreementBase
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class ResponseGetAgreementBase extends AgreementBase
+{
+
+}

--- a/src/Model/RecurringPayment/ResponseUpdateAgreement.php
+++ b/src/Model/RecurringPayment/ResponseUpdateAgreement.php
@@ -27,4 +27,18 @@ class ResponseUpdateAgreement
     {
         return $this->agreementId;
     }
+
+    /**
+     * Set the value of agreementId
+     *
+     * @param  string  $agreementId
+     *
+     * @return  self
+     */ 
+    public function setAgreementId(string $agreementId)
+    {
+        $this->agreementId = $agreementId;
+
+        return $this;
+    }
 }

--- a/src/Model/RecurringPayment/v2/Agreement.php
+++ b/src/Model/RecurringPayment/v2/Agreement.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v2;
+
+use JMS\Serializer\Annotation as Serializer;
+use zaporylie\Vipps\Model\RecurringPayment\AgreementBase;
+
+/**
+ * Class Agreement
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class Agreement extends AgreementBase
+{
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest")
+     */
+    protected $campaign;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $currency;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $interval;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $intervalCount;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $price;
+
+
+    /**
+     * Gets campaign value.
+     *
+     * @return \zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest
+     */
+    public function getCampaign()
+    {
+        return $this->campaign;
+    }
+
+    /**
+     * Gets currency value.
+     *
+     * @return string
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * Gets interval value.
+     *
+     * @return string
+     */
+    public function getInterval()
+    {
+        return $this->interval;
+    }
+
+    /**
+     * Gets intervalCount value.
+     *
+     * @return int
+     */
+    public function getIntervalCount()
+    {
+        return $this->intervalCount;
+    }
+
+    /**
+     * Gets price value.
+     *
+     * @return int
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+}

--- a/src/Model/RecurringPayment/v2/CampaignRequest.php
+++ b/src/Model/RecurringPayment/v2/CampaignRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace zaporylie\Vipps\Model\RecurringPayment;
+namespace zaporylie\Vipps\Model\RecurringPayment\v2;
 
 use JMS\Serializer\Annotation as Serializer;
 

--- a/src/Model/RecurringPayment/v2/RequestCreateAgreement.php
+++ b/src/Model/RecurringPayment/v2/RequestCreateAgreement.php
@@ -13,8 +13,8 @@ use JMS\Serializer\Annotation as Serializer;
 class RequestCreateAgreement extends RequestCreateAgreementBase
 {
     /**
-     * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
-     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest")
      */
     protected $campaign;
 
@@ -93,7 +93,7 @@ class RequestCreateAgreement extends RequestCreateAgreementBase
     /**
      * Sets campaign variable.
      *
-     * @param \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest $campaign
+     * @param \zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest $campaign
      *
      * @return $this
      */

--- a/src/Model/RecurringPayment/v2/RequestCreateAgreement.php
+++ b/src/Model/RecurringPayment/v2/RequestCreateAgreement.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v2;
+
+use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class RequestCreateAgreement
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class RequestCreateAgreement extends RequestCreateAgreementBase
+{
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
+     */
+    protected $campaign;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $currency;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $customerPhoneNumber;
+
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\InitialCharge
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\InitialCharge")
+     */
+    protected $initialCharge;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $interval;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $intervalCount;
+
+    /**
+     * @var bool
+     * @Serializer\Type("boolean")
+     */
+    protected $isApp;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $merchantAgreementUrl;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $merchantRedirectUrl;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $price;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $productName;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $productDescription;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $scope;
+
+    /**
+     * Sets campaign variable.
+     *
+     * @param \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest $campaign
+     *
+     * @return $this
+     */
+    public function setCampaign(CampaignRequest $campaign)
+    {
+        $this->campaign = $campaign;
+        return $this;
+    }
+
+    /**
+     * Sets currency variable.
+     *
+     * @param string $currency
+     *
+     * @return $this
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+    /**
+     * Sets customerPhoneNumber variable.
+     *
+     * @param string $customerPhoneNumber
+     *
+     * @return $this
+     */
+    public function setCustomerPhoneNumber($customerPhoneNumber)
+    {
+        $this->customerPhoneNumber = $customerPhoneNumber;
+        return $this;
+    }
+
+    /**
+     * Sets initialCharge variable.
+     *
+     * @param \zaporylie\Vipps\Model\RecurringPayment\InitialCharge $initialCharge
+     *
+     * @return $this
+     */
+    public function setInitialCharge(\zaporylie\Vipps\Model\RecurringPayment\InitialCharge $initialCharge)
+    {
+        $this->initialCharge = $initialCharge;
+        return $this;
+    }
+
+    /**
+     * Sets interval variable.
+     *
+     * @param string $interval
+     *
+     * @return $this
+     */
+    public function setInterval($interval)
+    {
+        $this->interval = $interval;
+        return $this;
+    }
+
+    /**
+     * Sets intervalCount variable.
+     *
+     * @param int $intervalCount
+     *
+     * @return $this
+     */
+    public function setIntervalCount($intervalCount)
+    {
+        $this->intervalCount = $intervalCount;
+        return $this;
+    }
+
+    /**
+     * Sets isApp variable.
+     *
+     * @param bool $isApp
+     *
+     * @return $this
+     */
+    public function setIsApp($isApp)
+    {
+        $this->isApp = $isApp;
+        return $this;
+    }
+
+    /**
+     * Sets merchantAgreementUrl variable.
+     *
+     * @param string $merchantAgreementUrl
+     *
+     * @return $this
+     */
+    public function setMerchantAgreementUrl($merchantAgreementUrl)
+    {
+        $this->merchantAgreementUrl = $merchantAgreementUrl;
+        return $this;
+    }
+
+    /**
+     * Sets merchantRedirectUrl variable.
+     *
+     * @param string $merchantRedirectUrl
+     *
+     * @return $this
+     */
+    public function setMerchantRedirectUrl($merchantRedirectUrl)
+    {
+        $this->merchantRedirectUrl = $merchantRedirectUrl;
+        return $this;
+    }
+
+    /**
+     * Sets price variable.
+     *
+     * @param int $price
+     *
+     * @return $this
+     */
+    public function setPrice($price)
+    {
+        $this->price = $price;
+        return $this;
+    }
+
+    /**
+     * Sets productDescription variable.
+     *
+     * @param string $productDescription
+     *
+     * @return $this
+     */
+    public function setProductDescription($productDescription)
+    {
+        $this->productDescription = $productDescription;
+        return $this;
+    }
+
+    /**
+     * Sets productName variable.
+     *
+     * @param string $productName
+     *
+     * @return $this
+     */
+    public function setProductName($productName)
+    {
+        $this->productName = $productName;
+        return $this;
+    }
+
+    /**
+     * Sets scope variable.
+     *
+     * @param string $scope
+     *
+     * @return $this
+     */
+    public function setScope($scope)
+    {
+        $this->scope = $scope;
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v2/RequestUpdateAgreement.php
+++ b/src/Model/RecurringPayment/v2/RequestUpdateAgreement.php
@@ -13,7 +13,7 @@ use JMS\Serializer\Annotation as Serializer;
 class RequestUpdateAgreement extends RequestUpdateAgreementBase
 {
     /**
-     * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest
      * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
      */
     protected $campaign;
@@ -45,7 +45,7 @@ class RequestUpdateAgreement extends RequestUpdateAgreementBase
     /**
      * Sets campaign variable.
      *
-     * @param \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest $campaign
+     * @param \zaporylie\Vipps\Model\RecurringPayment\v2\CampaignRequest $campaign
      *
      * @return $this
      */

--- a/src/Model/RecurringPayment/v2/RequestUpdateAgreement.php
+++ b/src/Model/RecurringPayment/v2/RequestUpdateAgreement.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace zaporylie\Vipps\Model\RecurringPayment;
+namespace zaporylie\Vipps\Model\RecurringPayment\v2;
 
+use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
@@ -9,7 +10,7 @@ use JMS\Serializer\Annotation as Serializer;
  *
  * @package Vipps\Model\RecurringPayment
  */
-class RequestUpdateAgreement
+class RequestUpdateAgreement extends RequestUpdateAgreementBase
 {
     /**
      * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest

--- a/src/Model/RecurringPayment/v2/ResponseGetAgreement.php
+++ b/src/Model/RecurringPayment/v2/ResponseGetAgreement.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace zaporylie\Vipps\Model\RecurringPayment;
+namespace zaporylie\Vipps\Model\RecurringPayment\v2;
 
 use JMS\Serializer\Annotation as Serializer;
 

--- a/src/Model/RecurringPayment/v3/Agreement.php
+++ b/src/Model/RecurringPayment/v3/Agreement.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use JMS\Serializer\Annotation as Serializer;
+use zaporylie\Vipps\Model\RecurringPayment\AgreementBase;
+
+/**
+ * Class Agreement
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class Agreement extends AgreementBase
+{
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest")
+     */
+    protected $campaign;
+
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\Period
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\Period")
+     */
+    protected $interval;
+
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\Pricing
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\Pricing")
+     */
+    protected $pricing;
+
+    /**
+     * Gets interval value.
+     *
+     * @return \zaporylie\Vipps\Model\RecurringPayment\v3\Period
+     */
+    public function getInterval()
+    {
+        return $this->interval;
+    }
+
+    /**
+     * Gets price value.
+     *
+     * @return \zaporylie\Vipps\Model\RecurringPayment\v3\Pricing
+     */
+    public function getPricing()
+    {
+        return $this->pricing;
+    }
+
+    /**
+     * Gets campaign value.
+     *
+     * @return \zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest
+     */
+    public function getCampaign()
+    {
+        return $this->campaign;
+    }
+}

--- a/src/Model/RecurringPayment/v3/Campaign/EventCampaign.php
+++ b/src/Model/RecurringPayment/v3/Campaign/EventCampaign.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3\Campaign;
+
+use JMS\Serializer\Annotation as Serializer;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignType;
+
+/**
+ * Class EventCampaign
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class EventCampaign extends CampaignRequest
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $type = CampaignType::EVENT_CAMPAIGN;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $price;
+
+    /**
+     * @var \DateTimeInterface
+     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s\Z'>")
+     */
+    protected $eventDate;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $eventText;
+
+
+    /**
+     * Get the value of type
+     *
+     * @return  string
+     */ 
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get the value of campaignPrice
+     *
+     * @return  int
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * Set the value of campaignPrice
+     *
+     * @param  int  $campaignPrice
+     *
+     * @return  self
+     */
+    public function setPrice(int $price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * @return  \DateTimeInterface
+     */ 
+    public function getEventDate()
+    {
+        return $this->eventDate;
+    }
+
+    /**
+     * @param  \DateTimeInterface  $eventDate
+     *
+     * @return  self
+     */ 
+    public function setEventDate($eventDate)
+    {
+        $this->eventDate = $eventDate;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of eventText
+     *
+     * @return  string
+     */ 
+    public function getEventText()
+    {
+        return $this->eventText;
+    }
+
+    /**
+     * Set the value of eventText
+     *
+     * @param  string  $eventText
+     *
+     * @return  self
+     */ 
+    public function setEventText(string $eventText)
+    {
+        $this->eventText = $eventText;
+
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/Campaign/FullFlexCampaign.php
+++ b/src/Model/RecurringPayment/v3/Campaign/FullFlexCampaign.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3\Campaign;
+
+use JMS\Serializer\Annotation as Serializer;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignType;
+
+/**
+ * Class FullFlexCampaign
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class FullFlexCampaign extends CampaignRequest
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $type = CampaignType::FULL_FLEX_CAMPAIGN;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $price;
+
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\Period
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\Period");
+     */
+    protected $interval;
+
+    /**
+     * @var \DateTimeInterface
+     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s\Z'>")
+     */
+    protected $end;
+
+
+    /**
+     * Get the value of end
+     *
+     * @return  \DateTimeInterface
+     */
+    public function getEnd()
+    {
+        return $this->end;
+    }
+
+    /**
+     * Get the value of campaignPrice
+     *
+     * @return  int
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * Set the value of campaignPrice
+     *
+     * @param  int  $campaignPrice
+     *
+     * @return  self
+     */
+    public function setPrice(int $price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of interval
+     *
+     * @return  \zaporylie\Vipps\Model\RecurringPayment\v3\Period
+     */ 
+    public function getInterval()
+    {
+        return $this->interval;
+    }
+
+    /**
+     * Set the value of interval
+     *
+     * @param  \zaporylie\Vipps\Model\RecurringPayment\v3\Period  $interval
+     *
+     * @return  self
+     */ 
+    public function setInterval(\zaporylie\Vipps\Model\RecurringPayment\v3\Period $interval)
+    {
+        $this->interval = $interval;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of type
+     *
+     * @return  string
+     */ 
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Set the value of end
+     *
+     * @param  \DateTimeInterface  $end
+     *
+     * @return  self
+     */
+    public function setEnd(\DateTimeInterface $end)
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/Campaign/PeriodCampaign.php
+++ b/src/Model/RecurringPayment/v3/Campaign/PeriodCampaign.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3\Campaign;
+
+use JMS\Serializer\Annotation as Serializer;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignType;
+
+/**
+ * Class PeriodCampaign
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class PeriodCampaign extends CampaignRequest
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $type = CampaignType::PERIOD_CAMPAIGN;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $price;
+
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\Period
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\Period")
+     */
+    protected $period;
+
+
+    /**
+     * Get the value of type
+     *
+     * @return  string
+     */ 
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get the value of campaignPrice
+     *
+     * @return  int
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * Set the value of campaignPrice
+     *
+     * @param  int  $campaignPrice
+     *
+     * @return  self
+     */
+    public function setPrice(int $price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+     /**
+     * @return  \zaporylie\Vipps\Model\RecurringPayment\v3\Period
+     */ 
+    public function getPeriod()
+    {
+        return $this->period;
+    }
+
+    /**
+     * @param  \zaporylie\Vipps\Model\RecurringPayment\v3\Period  $period
+     *
+     * @return  self
+     */ 
+    public function setPeriod(\zaporylie\Vipps\Model\RecurringPayment\v3\Period $period)
+    {
+        $this->period = $period;
+
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/Campaign/PriceCampaign.php
+++ b/src/Model/RecurringPayment/v3/Campaign/PriceCampaign.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3\Campaign;
+
+use JMS\Serializer\Annotation as Serializer;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest;
+use zaporylie\Vipps\Model\RecurringPayment\v3\CampaignType;
+
+/**
+ * Class PriceCampaign
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class PriceCampaign extends CampaignRequest
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $type = CampaignType::PRICE_CAMPAIGN;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $price;
+
+    /**
+     * @var \DateTimeInterface
+     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s\Z'>")
+     */
+    protected $end;
+
+
+    /**
+     * Get the value of type
+     *
+     * @return  string
+     */ 
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get the value of campaignPrice
+     *
+     * @return  int
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * Set the value of campaignPrice
+     *
+     * @param  int  $campaignPrice
+     *
+     * @return  self
+     */
+    public function setPrice(int $price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of end
+     *
+     * @return  \DateTimeInterface
+     */
+    public function getEnd()
+    {
+        return $this->end;
+    }
+
+    /**
+     * Set the value of end
+     *
+     * @param  \DateTimeInterface  $end
+     *
+     * @return  self
+     */
+    public function setEnd(\DateTimeInterface $end)
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/CampaignRequest.php
+++ b/src/Model/RecurringPayment/v3/CampaignRequest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class CampaignRequest
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class CampaignRequest
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $type;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $price;
+
+    /**
+     * @var Period
+     * @Serializer\Type("Period")
+     */
+    protected $interval;
+
+    /**
+     * @var Period
+     * @Serializer\Type("Period")
+     */
+    protected $period;
+
+    /**
+     * @var \DateTimeInterface
+     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s\Z'>")
+     */
+    protected $end;
+
+    /**
+     * Only required for type eventCampaignV3
+     * @var \DateTimeInterface
+     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s\Z'>")
+     */
+    protected $eventDate;
+
+    /**
+     * Get the value of end
+     *
+     * @return  \DateTimeInterface
+     */
+    public function getEnd()
+    {
+        return $this->end;
+    }
+
+    /**
+     * Set the value of end
+     *
+     * @param  \DateTimeInterface  $end
+     *
+     * @return  self
+     */
+    public function setEnd(\DateTimeInterface $end)
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of campaignPrice
+     *
+     * @return  int
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * Set the value of campaignPrice
+     *
+     * @param  int  $campaignPrice
+     *
+     * @return  self
+     */
+    public function setPrice(int $price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of interval
+     *
+     * @return  Period
+     */ 
+    public function getInterval()
+    {
+        return $this->interval;
+    }
+
+    /**
+     * Set the value of interval
+     *
+     * @param  Period  $interval
+     *
+     * @return  self
+     */ 
+    public function setInterval(Period $interval)
+    {
+        $this->interval = $interval;
+
+        return $this;
+    }
+
+    /**
+     * @return  Period
+     */ 
+    public function getPeriod()
+    {
+        return $this->period;
+    }
+
+    /**
+     * @param  Period  $period  Only required for type periodChampaignV3
+     *
+     * @return  self
+     */ 
+    public function setPeriod(Period $period)
+    {
+        $this->period = $period;
+
+        return $this;
+    }
+
+    /**
+     * @return  \DateTimeInterface
+     */ 
+    public function getEventDate()
+    {
+        return $this->eventDate;
+    }
+
+    /**
+     * @param  \DateTimeInterface  $eventDate
+     *
+     * @return  self
+     */ 
+    public function setEventDate($eventDate)
+    {
+        $this->eventDate = $eventDate;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of type
+     *
+     * @return  string
+     */ 
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Set the value of type
+     *
+     * @param  string  $type
+     *
+     * @return  self
+     */ 
+    public function setType(string $type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/CampaignType.php
+++ b/src/Model/RecurringPayment/v3/CampaignType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use Eloquent\Enumeration\AbstractEnumeration;
+
+/**
+ * Class CampaignType
+ *
+ * @todo: Currently this package is not used anywhere in the project. Use it for
+ * reference and comparison only.
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class CampaignType extends AbstractEnumeration
+{
+    const FULL_FLEX_CAMPAIGN = 'FULL_FLEX_CAMPAIGN';
+    const EVENT_CAMPAIGN = 'EVENT_CAMPAIGN';
+    const PERIOD_CAMPAIGN = 'PERIOD_CAMPAIGN';
+    const PRICE_CAMPAIGN = 'PRICE_CAMPAIGN';
+}

--- a/src/Model/RecurringPayment/v3/Period.php
+++ b/src/Model/RecurringPayment/v3/Period.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class Period.
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class Period
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $unit;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $count;
+
+    /**
+     * Sets unit variable.
+     *
+     * @param string $unit
+     *
+     * @return $this
+     */
+    public function setUnit($unit)
+    {
+        $this->unit = $unit;
+        return $this;
+    }
+
+    /**
+     * Sets count variable.
+     *
+     * @param int $count
+     *
+     * @return $this
+     */
+    public function setCount($count)
+    {
+        $this->count = $count;
+        return $this;
+    }
+
+}

--- a/src/Model/RecurringPayment/v3/Pricing.php
+++ b/src/Model/RecurringPayment/v3/Pricing.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class Pricing.
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class Pricing
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $type;
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $amount;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $currency;
+
+    /**
+     * @var int
+     * @Serializer\Type("int")
+     */
+    protected $suggestedMaxAmount;
+
+    /**
+     * Sets type variable.
+     *
+     * @param string $type
+     *
+     * @return $this
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Sets amount variable.
+     *
+     * @param int $amount
+     *
+     * @return $this
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+        return $this;
+    }
+
+    /**
+     * Sets currency variable.
+     *
+     * @param string $currency
+     *
+     * @return $this
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+
+    /**
+     * Set the value of suggestedMaxAmount
+     *
+     * @param  int  $suggestedMaxAmount
+     *
+     * @return  self
+     */ 
+    public function setSuggestedMaxAmount($suggestedMaxAmount)
+    {
+        $this->suggestedMaxAmount = $suggestedMaxAmount;
+
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/PricingType.php
+++ b/src/Model/RecurringPayment/v3/PricingType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use Eloquent\Enumeration\AbstractEnumeration;
+
+/**
+ * Class PricingType
+ *
+ * @todo: Currently this package is not used anywhere in the project. Use it for
+ * reference and comparison only.
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class PricingType extends AbstractEnumeration
+{
+    const LEGACY = 'LEGACY';
+    const VARIABLE = 'VARIABLE';
+}

--- a/src/Model/RecurringPayment/v3/RequestCaptureCharge.php
+++ b/src/Model/RecurringPayment/v3/RequestCaptureCharge.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use JMS\Serializer\Annotation as Serializer;
+
+
+/**
+ * Class RequestCaptureCharge
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class RequestCaptureCharge {
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    protected $amount;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $description;
+
+    /**
+     * Get the value of amount
+     *
+     * @return  int
+     */ 
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * Set the value of amount
+     *
+     * @param  int  $amount
+     *
+     * @return  self
+     */ 
+    public function setAmount(int $amount)
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of description
+     *
+     * @return  string
+     */ 
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set the value of description
+     *
+     * @param  string  $description
+     *
+     * @return  self
+     */ 
+    public function setDescription(string $description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/RequestCreateAgreement.php
+++ b/src/Model/RecurringPayment/v3/RequestCreateAgreement.php
@@ -1,34 +1,37 @@
 <?php
 
-namespace zaporylie\Vipps\Model\RecurringPayment;
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
 
+use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase;
 use JMS\Serializer\Annotation as Serializer;
+
 
 /**
  * Class RequestCreateAgreement
  *
  * @package Vipps\Model\RecurringPayment
  */
-class RequestCreateAgreement
+class RequestCreateAgreement extends RequestCreateAgreementBase
 {
     /**
-     * @var \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest
-     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\CampaignRequest")
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest")
      */
     protected $campaign;
 
     /**
-     * @var string
-     * @Serializer\Type("string")
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\Pricing
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\Pricing")
      */
-    protected $currency;
+    protected $pricing;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $customerPhoneNumber;
+    protected $phoneNumber;
 
+    //TODO: Check if this is changed in v3
     /**
      * @var \zaporylie\Vipps\Model\RecurringPayment\InitialCharge
      * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\InitialCharge")
@@ -36,16 +39,10 @@ class RequestCreateAgreement
     protected $initialCharge;
 
     /**
-     * @var string
-     * @Serializer\Type("string")
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\Period
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\Period")
      */
     protected $interval;
-
-    /**
-     * @var int
-     * @Serializer\Type("integer")
-     */
-    protected $intervalCount;
 
     /**
      * @var bool
@@ -66,12 +63,6 @@ class RequestCreateAgreement
     protected $merchantRedirectUrl;
 
     /**
-     * @var int
-     * @Serializer\Type("integer")
-     */
-    protected $price;
-
-    /**
      * @var string
      * @Serializer\Type("string")
      */
@@ -90,9 +81,27 @@ class RequestCreateAgreement
     protected $scope;
 
     /**
+     * @var bool
+     * @Serializer\Type("boolean")
+     */
+    protected $skipLandingPage;
+    
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $externalId;
+   
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $countryCode;
+   
+    /**
      * Sets campaign variable.
      *
-     * @param \zaporylie\Vipps\Model\RecurringPayment\CampaignRequest $campaign
+     * @param \zaporylie\Vipps\Model\RecurringPayment\v3\CampaignRequest $campaign
      *
      * @return $this
      */
@@ -103,28 +112,28 @@ class RequestCreateAgreement
     }
 
     /**
-     * Sets currency variable.
+     * Set the value of pricing
      *
-     * @param string $currency
+     * @param  \zaporylie\Vipps\Model\RecurringPayment\v3\Pricing  $pricing
      *
-     * @return $this
-     */
-    public function setCurrency($currency)
+     * @return  self
+     */ 
+    public function setPricing(\zaporylie\Vipps\Model\RecurringPayment\v3\Pricing $pricing)
     {
-        $this->currency = $currency;
+        $this->pricing = $pricing;
         return $this;
     }
 
     /**
-     * Sets customerPhoneNumber variable.
+     * Sets phoneNumber variable.
      *
-     * @param string $customerPhoneNumber
+     * @param string $phoneNumber
      *
      * @return $this
      */
-    public function setCustomerPhoneNumber($customerPhoneNumber)
+    public function setPhoneNumber($phoneNumber)
     {
-        $this->customerPhoneNumber = $customerPhoneNumber;
+        $this->phoneNumber = $phoneNumber;
         return $this;
     }
 
@@ -135,7 +144,7 @@ class RequestCreateAgreement
      *
      * @return $this
      */
-    public function setInitialCharge(InitialCharge $initialCharge)
+    public function setInitialCharge(\zaporylie\Vipps\Model\RecurringPayment\InitialCharge $initialCharge)
     {
         $this->initialCharge = $initialCharge;
         return $this;
@@ -144,26 +153,13 @@ class RequestCreateAgreement
     /**
      * Sets interval variable.
      *
-     * @param string $interval
+     * @param \zaporylie\Vipps\Model\RecurringPayment\v3\Period $interval
      *
      * @return $this
      */
-    public function setInterval($interval)
+    public function setInterval(\zaporylie\Vipps\Model\RecurringPayment\v3\Period $interval)
     {
         $this->interval = $interval;
-        return $this;
-    }
-
-    /**
-     * Sets intervalCount variable.
-     *
-     * @param int $intervalCount
-     *
-     * @return $this
-     */
-    public function setIntervalCount($intervalCount)
-    {
-        $this->intervalCount = $intervalCount;
         return $this;
     }
 
@@ -207,18 +203,18 @@ class RequestCreateAgreement
     }
 
     /**
-     * Sets price variable.
+     * Sets productName variable.
      *
-     * @param int $price
+     * @param string $productName
      *
      * @return $this
      */
-    public function setPrice($price)
+    public function setProductName($productName)
     {
-        $this->price = $price;
+        $this->productName = $productName;
         return $this;
     }
-
+    
     /**
      * Sets productDescription variable.
      *
@@ -232,18 +228,6 @@ class RequestCreateAgreement
         return $this;
     }
 
-    /**
-     * Sets productName variable.
-     *
-     * @param string $productName
-     *
-     * @return $this
-     */
-    public function setProductName($productName)
-    {
-        $this->productName = $productName;
-        return $this;
-    }
 
     /**
      * Sets scope variable.
@@ -255,6 +239,48 @@ class RequestCreateAgreement
     public function setScope($scope)
     {
         $this->scope = $scope;
+        return $this;
+    }
+
+    /**
+     * Set the value of skipLandingPage
+     *
+     * @param  bool  $skipLandingPage
+     *
+     * @return  self
+     */ 
+    public function setSkipLandingPage($skipLandingPage)
+    {
+        $this->skipLandingPage = $skipLandingPage;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of externalId
+     *
+     * @param  string  $externalId
+     *
+     * @return  self
+     */ 
+    public function setExternalId($externalId)
+    {
+        $this->externalId = $externalId;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of countryCode
+     *
+     * @param  string  $countryCode
+     *
+     * @return  self
+     */ 
+    public function setCountryCode($countryCode)
+    {
+        $this->countryCode = $countryCode;
+
         return $this;
     }
 }

--- a/src/Model/RecurringPayment/v3/RequestUpdateAgreement.php
+++ b/src/Model/RecurringPayment/v3/RequestUpdateAgreement.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class RequestUpdateAgreement
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class RequestUpdateAgreement extends RequestUpdateAgreementBase
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $productName;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $productDescription;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $merchantAgreementUrl;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $externalId;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $status;
+
+    /**
+     * @var \zaporylie\Vipps\Model\RecurringPayment\v3\Pricing
+     * @Serializer\Type("zaporylie\Vipps\Model\RecurringPayment\v3\Pricing")
+     */
+    protected $pricing;
+
+
+    /**
+     * Sets productName variable.
+     *
+     * @param string $productName
+     *
+     * @return $this
+     */
+    public function setProductName($productName)
+    {
+        $this->productName = $productName;
+        return $this;
+    }
+
+    /**
+     * Sets productDescription variable.
+     *
+     * @param string $productDescription
+     *
+     * @return $this
+     */
+    public function setProductDescription($productDescription)
+    {
+        $this->productDescription = $productDescription;
+        return $this;
+    }
+
+    /**
+     * Sets merchantAgreementUrl variable.
+     *
+     * @param string $merchantAgreementUrl
+     *
+     * @return $this
+     */
+    public function setMerchantAgreementUrl($merchantAgreementUrl)
+    {
+        $this->merchantAgreementUrl = $merchantAgreementUrl;
+        return $this;
+    }
+
+    /**
+     * Set the value of externalId
+     *
+     * @param  string  $externalId
+     *
+     * @return  self
+     */ 
+    public function setExternalId($externalId)
+    {
+        $this->externalId = $externalId;
+
+        return $this;
+    }
+
+    /**
+     * Sets status variable.
+     *
+     * @param string $status
+     *
+     * @return $this
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    /**
+     * Set the value of pricing
+     *
+     * @param  \zaporylie\Vipps\Model\RecurringPayment\v3\Pricing  $pricing
+     *
+     * @return  self
+     */ 
+    public function setPricing(\zaporylie\Vipps\Model\RecurringPayment\v3\Pricing $pricing)
+    {
+        $this->pricing = $pricing;
+        return $this;
+    }
+}

--- a/src/Model/RecurringPayment/v3/ResponseGetAgreement.php
+++ b/src/Model/RecurringPayment/v3/ResponseGetAgreement.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace zaporylie\Vipps\Model\RecurringPayment\v3;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class ResponseGetAgreement
+ *
+ * @package Vipps\Model\RecurringPayment
+ */
+class ResponseGetAgreement extends Agreement
+{
+
+}

--- a/src/Resource/RecurringPayment/CancelCharge.php
+++ b/src/Resource/RecurringPayment/CancelCharge.php
@@ -26,7 +26,7 @@ class CancelCharge extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}/charges/{charge_id}';
 
     /**
      * CancelCharge constructor.
@@ -37,14 +37,15 @@ class CancelCharge extends RecurringPaymentResourceBase
      * @param string $charge_id
      */
     public function __construct(
-        VippsInterface $vipps,
+        VippsInterface $vipps, 
+        $api_endpoint_version,
         $subscription_key,
         $agreement_id,
         $charge_id
     ) {
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $subscription_key, $api_endpoint_version);
     }
 
     /**

--- a/src/Resource/RecurringPayment/CancelCharge.php
+++ b/src/Resource/RecurringPayment/CancelCharge.php
@@ -45,7 +45,7 @@ class CancelCharge extends RecurringPaymentResourceBase
     ) {
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
-        parent::__construct($vipps, $subscription_key, $api_endpoint_version);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
     }
 
     /**

--- a/src/Resource/RecurringPayment/CaptureCharge.php
+++ b/src/Resource/RecurringPayment/CaptureCharge.php
@@ -45,7 +45,7 @@ class CaptureCharge extends RecurringPaymentResourceBase
     ) {
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
-        parent::__construct($vipps, $subscription_key, $api_endpoint_version);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
     }
 
     /**

--- a/src/Resource/RecurringPayment/CaptureCharge.php
+++ b/src/Resource/RecurringPayment/CaptureCharge.php
@@ -5,6 +5,7 @@ namespace zaporylie\Vipps\Resource\RecurringPayment;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateCharge;
 use zaporylie\Vipps\Model\RecurringPayment\ResponseCaptureCharge;
 use zaporylie\Vipps\Model\RecurringPayment\ResponseCreateCharge;
+use zaporylie\Vipps\Model\RecurringPayment\v3\RequestCaptureCharge;
 use zaporylie\Vipps\Resource\HttpMethod;
 use zaporylie\Vipps\Resource\IdempotencyKeyFactory;
 use zaporylie\Vipps\Resource\RequestIdFactory;
@@ -41,11 +42,18 @@ class CaptureCharge extends RecurringPaymentResourceBase
         $api_endpoint_version,
         $subscription_key,
         $agreement_id,
-        $charge_id
+        $charge_id,
+        RequestCaptureCharge $requestObject
     ) {
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
         parent::__construct($vipps, $api_endpoint_version, $subscription_key);
+        $this->body = $this
+        ->getSerializer()
+        ->serialize(
+            $requestObject,
+            'json'
+        );
     }
 
     /**

--- a/src/Resource/RecurringPayment/CaptureCharge.php
+++ b/src/Resource/RecurringPayment/CaptureCharge.php
@@ -26,7 +26,7 @@ class CaptureCharge extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}/capture';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}/charges/{charge_id}/capture';
 
     /**
      * InitiatePayment constructor.
@@ -38,15 +38,14 @@ class CaptureCharge extends RecurringPaymentResourceBase
      */
     public function __construct(
         VippsInterface $vipps,
+        $api_endpoint_version,
         $subscription_key,
         $agreement_id,
         $charge_id
     ) {
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
-        // By default RequestID is different for each Resource object.
-        $this->headers['Idempotency-Key'] = IdempotencyKeyFactory::generate();
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $subscription_key, $api_endpoint_version);
     }
 
     /**

--- a/src/Resource/RecurringPayment/CreateAgreement.php
+++ b/src/Resource/RecurringPayment/CreateAgreement.php
@@ -30,7 +30,7 @@ class CreateAgreement extends RecurringPaymentResourceBase
      *
      * @param \zaporylie\Vipps\VippsInterface $vipps
      * @param string $subscription_key
-     * @param \zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement $requestObject
+     * @param \zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase $requestObject
      */
     public function __construct(VippsInterface $vipps, $api_endpoint_version, $subscription_key, RequestCreateAgreementBase $requestObject)
     {

--- a/src/Resource/RecurringPayment/CreateAgreement.php
+++ b/src/Resource/RecurringPayment/CreateAgreement.php
@@ -2,9 +2,9 @@
 
 namespace zaporylie\Vipps\Resource\RecurringPayment;
 
-use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement;
-use zaporylie\Vipps\Model\RecurringPayment\ResponseCreateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreementBase;
 use zaporylie\Vipps\Resource\HttpMethod;
+use zaporylie\Vipps\Resource\IdempotencyKeyFactory;
 use zaporylie\Vipps\VippsInterface;
 
 /**
@@ -23,7 +23,7 @@ class CreateAgreement extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements';
 
     /**
      * InitiatePayment constructor.
@@ -32,9 +32,9 @@ class CreateAgreement extends RecurringPaymentResourceBase
      * @param string $subscription_key
      * @param \zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement $requestObject
      */
-    public function __construct(VippsInterface $vipps, $subscription_key, RequestCreateAgreement $requestObject)
+    public function __construct(VippsInterface $vipps, $api_endpoint_version, $subscription_key, RequestCreateAgreementBase $requestObject)
     {
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
         $this->body = $this
             ->getSerializer()
             ->serialize(
@@ -55,7 +55,7 @@ class CreateAgreement extends RecurringPaymentResourceBase
             ->getSerializer()
             ->deserialize(
                 $body,
-                ResponseCreateAgreement::class,
+                \zaporylie\Vipps\Model\RecurringPayment\ResponseCreateAgreement::class,
                 'json'
             );
 

--- a/src/Resource/RecurringPayment/CreateCharge.php
+++ b/src/Resource/RecurringPayment/CreateCharge.php
@@ -25,7 +25,7 @@ class CreateCharge extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}/charges';
 
     /**
      * InitiatePayment constructor.
@@ -37,14 +37,13 @@ class CreateCharge extends RecurringPaymentResourceBase
      */
     public function __construct(
         VippsInterface $vipps,
+        $api_endpoint_version,
         $subscription_key,
         $agreementId,
         RequestCreateCharge $requestObject
     ) {
         $this->id = $agreementId;
-        // By default RequestID is different for each Resource object.
-        $this->headers['Idempotency-Key'] = IdempotencyKeyFactory::generate();
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
         $this->body = $this
             ->getSerializer()
             ->serialize(

--- a/src/Resource/RecurringPayment/GetAgreement.php
+++ b/src/Resource/RecurringPayment/GetAgreement.php
@@ -2,7 +2,9 @@
 
 namespace zaporylie\Vipps\Resource\RecurringPayment;
 
-use zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreementBase;
+use zaporylie\Vipps\Model\RecurringPayment\v2\ResponseGetAgreement as ResponseGetAgreementV2; 
+use zaporylie\Vipps\Model\RecurringPayment\v3\ResponseGetAgreement as ResponseGetAgreementV3;
 use zaporylie\Vipps\Resource\HttpMethod;
 use zaporylie\Vipps\VippsInterface;
 
@@ -22,7 +24,7 @@ class GetAgreement extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}';
 
     /**
      * InitiatePayment constructor.
@@ -31,25 +33,26 @@ class GetAgreement extends RecurringPaymentResourceBase
      * @param string $subscription_key
      * @param $agreement_id
      */
-    public function __construct(VippsInterface $vipps, $subscription_key, $agreement_id)
+    public function __construct(VippsInterface $vipps, $api_endpoint_version, $subscription_key, $agreement_id)
     {
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
         $this->id = $agreement_id;
     }
 
     /**
-     * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement
+     * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreementBase
      */
     public function call()
     {
         $response = $this->makeCall();
         $body = $response->getBody()->getContents();
-        /** @var \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement $responseObject */
+        /** @var \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreementBase $responseObject */
         $responseObject = $this
             ->getSerializer()
             ->deserialize(
                 $body,
-                ResponseGetAgreement::class,
+                //Not a good way to go about version management
+                $this->api_endpoint_version == 3 ? ResponseGetAgreementV3::class : ResponseGetAgreementV2::class,
                 'json'
             );
 

--- a/src/Resource/RecurringPayment/GetAgreements.php
+++ b/src/Resource/RecurringPayment/GetAgreements.php
@@ -3,6 +3,8 @@
 namespace zaporylie\Vipps\Resource\RecurringPayment;
 
 use zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\v2\ResponseGetAgreement as ResponseGetAgreementV2; 
+use zaporylie\Vipps\Model\RecurringPayment\v3\ResponseGetAgreement as ResponseGetAgreementV3;
 use zaporylie\Vipps\Resource\HttpMethod;
 
 /**
@@ -21,7 +23,7 @@ class GetAgreements extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements';
 
     /**
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement[]
@@ -35,7 +37,8 @@ class GetAgreements extends RecurringPaymentResourceBase
             ->getSerializer()
             ->deserialize(
                 $body,
-                sprintf("array<%s>", ResponseGetAgreement::class),
+                //Not a good way to go about version management
+                sprintf("array<%s>", $this->api_endpoint_version == 3 ? ResponseGetAgreementV3::class : ResponseGetAgreementV2::class),
                 'json'
             );
 

--- a/src/Resource/RecurringPayment/GetCharge.php
+++ b/src/Resource/RecurringPayment/GetCharge.php
@@ -21,15 +21,16 @@ class GetCharge extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}/charges/{charge_id}';
 
     public function __construct(
         \zaporylie\Vipps\VippsInterface $vipps,
+        $api_endpoint_version,
         $subscription_key,
         $agreement_id,
         $charge_id
     ) {
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
     }

--- a/src/Resource/RecurringPayment/GetCharges.php
+++ b/src/Resource/RecurringPayment/GetCharges.php
@@ -21,14 +21,15 @@ class GetCharges extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}/charges';
 
     public function __construct(
         \zaporylie\Vipps\VippsInterface $vipps,
+        $api_endpoint_version,
         $subscription_key,
         $agreement_id
     ) {
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
         $this->id = $agreement_id;
     }
 

--- a/src/Resource/RecurringPayment/RefundCharge.php
+++ b/src/Resource/RecurringPayment/RefundCharge.php
@@ -27,7 +27,7 @@ class RefundCharge extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}/refund';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}/charges/{charge_id}/refund';
 
     /**
      * RefundCharge constructor.
@@ -40,6 +40,7 @@ class RefundCharge extends RecurringPaymentResourceBase
      */
     public function __construct(
         VippsInterface $vipps,
+        $api_endpoint_version,
         $subscription_key,
         $agreement_id,
         $charge_id,
@@ -47,9 +48,8 @@ class RefundCharge extends RecurringPaymentResourceBase
     ) {
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
-        // By default RequestID is different for each Resource object.
-        $this->headers['Idempotency-Key'] = IdempotencyKeyFactory::generate();
-        parent::__construct($vipps, $subscription_key);
+        
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
         $this->body = $this
             ->getSerializer()
             ->serialize(

--- a/src/Resource/RecurringPayment/UpdateAgreement.php
+++ b/src/Resource/RecurringPayment/UpdateAgreement.php
@@ -2,7 +2,7 @@
 
 namespace zaporylie\Vipps\Resource\RecurringPayment;
 
-use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreementBase;
 use zaporylie\Vipps\Model\RecurringPayment\ResponseUpdateAgreement;
 use zaporylie\Vipps\Resource\HttpMethod;
 use zaporylie\Vipps\VippsInterface;
@@ -23,7 +23,7 @@ class UpdateAgreement extends RecurringPaymentResourceBase
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}';
+    protected $path = '/recurring/v{api_endpoint_version}/agreements/{id}';
 
     /**
      * InitiatePayment constructor.
@@ -35,11 +35,12 @@ class UpdateAgreement extends RecurringPaymentResourceBase
      */
     public function __construct(
         VippsInterface $vipps,
+        $api_endpoint_version,
         $subscription_key,
         $agreement_id,
-        RequestUpdateAgreement $requestObject
+        RequestUpdateAgreementBase $requestObject
     ) {
-        parent::__construct($vipps, $subscription_key);
+        parent::__construct($vipps, $api_endpoint_version, $subscription_key);
         $this->id = $agreement_id;
         $this->body = $this
             ->getSerializer()
@@ -57,14 +58,19 @@ class UpdateAgreement extends RecurringPaymentResourceBase
         $response = $this->makeCall();
         $body = $response->getBody()->getContents();
         /** @var \zaporylie\Vipps\Model\RecurringPayment\ResponseUpdateAgreement $responseObject */
-        $responseObject = $this
+        
+        if ($this->api_endpoint_version > 2) {
+            $responseObject = new ResponseUpdateAgreement();
+            $responseObject->setAgreementId($this->id);
+        } else {
+            $responseObject = $this
             ->getSerializer()
             ->deserialize(
                 $body,
                 ResponseUpdateAgreement::class,
                 'json'
             );
-
+        }
         return $responseObject;
     }
 }

--- a/src/Resource/ResourceBase.php
+++ b/src/Resource/ResourceBase.php
@@ -68,7 +68,6 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
     public function __construct(VippsInterface $vipps, $subscription_key)
     {
         $this->app = $vipps;
-
         $this->headers['Ocp-Apim-Subscription-Key'] = $subscription_key;
 
         // Initiate serializer.

--- a/src/Vipps.php
+++ b/src/Vipps.php
@@ -58,12 +58,13 @@ class Vipps implements VippsInterface
     /**
      * @param string $subscription_key
      * @param string $merchant_serial_number
+     * @param int $api_endpoint_version
      *
      * @return \zaporylie\Vipps\Api\RecurringPaymentInterface
      */
-    public function recurringPayment($subscription_key, $merchant_serial_number)
+    public function recurringPayment($subscription_key, $merchant_serial_number, $api_endpoint_version = 3)
     {
-        return new RecurringPayment($this, $subscription_key, $merchant_serial_number);
+        return new RecurringPayment($this, $subscription_key, $merchant_serial_number, $api_endpoint_version);
     }
 
     /**

--- a/src/VippsInterface.php
+++ b/src/VippsInterface.php
@@ -39,8 +39,9 @@ interface VippsInterface
     /**
      * @param string $subscription_key
      * @param string $merchant_serial_number
+     * @param int $api_endpoint_version
      *
      * @return \zaporylie\Vipps\Api\RecurringPaymentInterface
      */
-    public function recurringPayment($subscription_key, $merchant_serial_number);
+    public function recurringPayment($subscription_key, $merchant_serial_number, $api_endpoint_version = 3);
 }


### PR DESCRIPTION
A quick and dirty update that adds V3 support(But keeps v2 support available) since  june 1. marks the end of v2 deprication period
You might not want to pull it directly into 2.x as it contains a few breaking changes, and needs a bit of cleanup.

To keep compability working for v2 while migrating to v3:
- The RecurringPayments constructor now takes an api_version argument which defaults to 3 - Set this to 2
- Namespaces for:  RequestCreateAgreement, CampaignRequest, RequestUpdateAgreement and Agreement must be updated from ``zaporylie\Vipps\Model\RecurringPayment\`` to ``zaporylie\Vipps\Model\RecurringPayment\v2\`` 