### PR TITLE
PSR: replace php-http/client-implementation with psr/http-client-implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.{json,lock}]
+indent_size = 4

--- a/composer.json
+++ b/composer.json
@@ -6,25 +6,26 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "psr/http-message": "^1.0",
+        "psr/http-client-implementation": "^1.0",
         "php-http/message": "^1.6",
         "php-http/httplug": "^1.0 || ^2.0",
-        "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^1.0",
+        "php-http/discovery": "^1.17",
         "eloquent/enumeration": "^5.1",
         "jms/serializer": "^1.8 || ^3.0"
     },
     "require-dev": {
-        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
+        "guzzlehttp/guzzle": "^7",
         "phpunit/phpunit": ">=5 <9",
         "symfony/yaml": "^2.0",
         "symfony/filesystem": "^3.1",
         "squizlabs/php_codesniffer": "^3.0",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "editorconfig-checker/editorconfig-checker": "^10.4"
     },
     "suggest": {
-        "php-http/guzzle6-adapter": "Guzzle adapter"
+        "php-http/guzzle7-adapter": "Guzzle adapter"
     },
     "license": "MIT",
     "authors": [
@@ -37,17 +38,22 @@
         "test": [
             "composer test-style",
             "composer test-unit",
-	    "composer test-phpstan"
+            "composer test-phpstan"
         ],
         "test-style": "./vendor/bin/phpcs -p",
         "fix-style": "./vendor/bin/phpcbf -p",
         "test-unit": "./vendor/bin/phpunit",
-	"test-phpstan": "./vendor/bin/phpstan analyze"
+        "test-phpstan": "./vendor/bin/phpstan analyze"
     },
     "autoload": {
         "psr-4": { "zaporylie\\Vipps\\": "src/" }
     },
     "autoload-dev": {
         "psr-4": { "zaporylie\\Vipps\\Tests\\": "test/" }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,7 @@
     <file>./src</file>
     <file>./test/Unit</file>
     <file>./test/Integration</file>
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <rule ref="PSR2"/>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,22 +6,6 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: """
-				#^Call to method find\\(\\) of deprecated class Http\\\\Discovery\\\\MessageFactoryDiscovery\\:
-				This will be removed in 2\\.0\\. Consider using Psr17FactoryDiscovery\\.$#
-			"""
-			count: 1
-			path: src/Client.php
-
-		-
-			message: """
-				#^Call to method find\\(\\) of deprecated class Http\\\\Discovery\\\\UriFactoryDiscovery\\:
-				This will be removed in 2\\.0\\. Consider using Psr17FactoryDiscovery\\.$#
-			"""
-			count: 1
-			path: src/Endpoint.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Endpoint.php
@@ -33,73 +17,11 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 2
-			path: src/Model/Payment/ExpressCheckOutPaymentRequest.php
-
-		-
-			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 2
-			path: src/Model/Payment/FetchShippingCostAndMethod.php
-
-		-
-			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 1
-			path: src/Model/Payment/FetchShippingCostResponse.php
-
-		-
-			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 2
-			path: src/Model/Payment/RegularCheckOutPaymentRequest.php
-
-		-
-			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 1
-			path: src/Resource/ResourceBase.php
-
-		-
-			message: """
 				#^Call to deprecated method getOrderStatus\\(\\) of class zaporylie\\\\Vipps\\\\Api\\\\PaymentInterface\\:
 				Get order status was deprecated and can be removed in version 3\\.0\\.$#
 			"""
 			count: 1
 			path: test/Integration/Api/PaymentsTest.php
-
-		-
-			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 2
-			path: test/Integration/IntegrationTestBase.php
-
-		-
-			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 1
-			path: test/Unit/Authentication/TokenMemoryCacheStorageTest.php
 
 		-
 			message: "#^Call to an undefined static method zaporylie\\\\Vipps\\\\Endpoint\\:\\:error\\(\\)\\.$#"
@@ -127,24 +49,6 @@ parameters:
 			path: test/Unit/EndpointTest.php
 
 		-
-			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 1
-			path: test/Unit/Model/Error/AuthorizationErrorTest.php
-
-		-
-			message: """
-				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
-				This method is deprecated and will be removed in
-				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
-			"""
-			count: 1
-			path: test/Unit/Model/Error/PaymentErrorTest.php
-
-		-
 			message: "#^Class zaporylie\\\\Vipps\\\\Resource\\\\Payment\\\\GetOrderStatus constructor invoked with 4 parameters, 3 required\\.$#"
 			count: 1
 			path: test/Unit/Model/Payment/ResponseGetOrderStatusTest.php
@@ -161,27 +65,11 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/Authorization/GetTokenTest.php
-
-		-
-			message: """
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
 			count: 1
 			path: test/Unit/Resource/Authorization/GetTokenTest.php
-
-		-
-			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/Payment/CancelPaymentTest.php
 
 		-
 			message: """
@@ -193,27 +81,11 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/Payment/CapturePaymentTest.php
-
-		-
-			message: """
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
 			count: 1
 			path: test/Unit/Resource/Payment/CapturePaymentTest.php
-
-		-
-			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/Payment/GetOrderStatusTest.php
 
 		-
 			message: """
@@ -230,27 +102,11 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/Payment/GetPaymentDetailsTest.php
-
-		-
-			message: """
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
 			count: 1
 			path: test/Unit/Resource/Payment/GetPaymentDetailsTest.php
-
-		-
-			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/Payment/InitiatePaymentTest.php
 
 		-
 			message: """
@@ -262,24 +118,8 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/Payment/RefundPaymentTest.php
-
-		-
-			message: """
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
 			count: 1
 			path: test/Unit/Resource/Payment/RefundPaymentTest.php
-
-		-
-			message: """
-				#^Call to deprecated function GuzzleHttp\\\\Psr7\\\\stream_for\\(\\)\\:
-				stream_for will be removed in guzzlehttp/psr7\\:2\\.0\\. Use Utils\\:\\:streamFor instead\\.$#
-			"""
-			count: 1
-			path: test/Unit/Resource/ResourceBaseTest.php

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -2,6 +2,8 @@
 
 namespace zaporylie\Vipps;
 
+use Psr\Http\Client\ClientInterface as HttpClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use zaporylie\Vipps\Authentication\TokenStorageInterface;
 
 interface ClientInterface
@@ -39,7 +41,7 @@ interface ClientInterface
      *
      * @return \zaporylie\Vipps\EndpointInterface
      */
-    public function getEndpoint();
+    public function getEndpoint(): EndpointInterface;
 
     /**
      * Sets connection variable.
@@ -53,23 +55,23 @@ interface ClientInterface
     /**
      * Gets httpClient value.
      *
-     * @return \Http\Client\HttpAsyncClient|\Http\Client\HttpClient
+     * @return \Psr\Http\Client\ClientInterface
      */
-    public function getHttpClient();
+    public function getHttpClient() : HttpClientInterface;
 
     /**
      * Sets httpClient variable.
      *
-     * @param \Http\Client\HttpAsyncClient|\Http\Client\HttpClient $httpClient
+     * @param \Psr\Http\Client\ClientInterface|null $httpClient
      *
      * @return $this
      */
-    public function setHttpClient($httpClient);
+    public function setHttpClient(?HttpClientInterface $httpClient);
 
     /**
      * Gets messageFactory value.
      *
-     * @return \Http\Message\MessageFactory
+     * @return \Psr\Http\Message\RequestFactoryInterface
      */
-    public function getMessageFactory();
+    public function getRequestFactory(): RequestFactoryInterface;
 }

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -9,6 +9,7 @@
 namespace zaporylie\Vipps;
 
 use Eloquent\Enumeration\AbstractMultiton;
+use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 
 /**
@@ -111,7 +112,7 @@ class Endpoint extends AbstractMultiton implements EndpointInterface
      */
     public function getUri()
     {
-        $uri = UriFactoryDiscovery::find();
+        $uri = Psr17FactoryDiscovery::findUriFactory();
         return $uri->createUri(sprintf(
             '%s://%s:%s%s',
             $this->getScheme(),

--- a/src/Model/FromStringTrait.php
+++ b/src/Model/FromStringTrait.php
@@ -13,7 +13,9 @@ trait FromStringTrait
     public static function fromString($string, SerializerInterface $serializer = null)
     {
         if (!isset($serializer) && in_array(SupportsSerializationInterface::class, class_implements(static::class))) {
-            AnnotationRegistry::registerLoader('class_exists');
+            if (class_exists(AnnotationRegistry::class) && method_exists(AnnotationRegistry::class, 'registerLoader')) {
+                AnnotationRegistry::registerLoader('class_exists');
+            }
             $serializer = static::getSerializer();
         } elseif (!isset($serializer)) {
             throw new \InvalidArgumentException(sprintf('Missing %s', SerializerInterface::class));

--- a/src/Model/ToStringTrait.php
+++ b/src/Model/ToStringTrait.php
@@ -13,7 +13,9 @@ trait ToStringTrait
     public function toString()
     {
         if (!isset($this->serializer) && ($this instanceof SupportsSerializationInterface)) {
-            AnnotationRegistry::registerLoader('class_exists');
+            if (class_exists(AnnotationRegistry::class) && method_exists(AnnotationRegistry::class, 'registerLoader')) {
+                AnnotationRegistry::registerLoader('class_exists');
+            }
             $serializer = static::getSerializer();
         } elseif (!isset($this->serializer)) {
             throw new \InvalidArgumentException(sprintf('Missing %s', SerializerInterface::class));

--- a/test/Integration/IntegrationTestBase.php
+++ b/test/Integration/IntegrationTestBase.php
@@ -2,11 +2,8 @@
 
 namespace zaporylie\Vipps\Tests\Integration;
 
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
-use Http\Client\Exception\HttpException;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
 use zaporylie\Vipps\Client;
 use zaporylie\Vipps\Tests\Unit\Authentication\TestTokenStorage;
@@ -16,7 +13,7 @@ abstract class IntegrationTestBase extends TestCase
 {
 
     /**
-     * @var \Http\Client\HttpClient|\Http\Client\HttpAsyncClient|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Psr\Http\Client\ClientInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $httpClient;
 
@@ -41,7 +38,7 @@ abstract class IntegrationTestBase extends TestCase
     protected function setUp() : void
     {
         parent::setUp();
-        $this->httpClient = $this->getMockBuilder(HttpClient::class)
+        $this->httpClient = $this->getMockBuilder(ClientInterface::class)
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->disableArgumentCloning()
@@ -75,7 +72,7 @@ abstract class IntegrationTestBase extends TestCase
      */
     public static function getResponse(array $content = [])
     {
-        return new Response(200, [], stream_for(json_encode($content)));
+        return new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode($content)));
     }
 
     /**
@@ -89,6 +86,6 @@ abstract class IntegrationTestBase extends TestCase
                 'error_message' => 'test_token_type',
             ];
         }
-        return new Response($error_code, [], stream_for(json_encode($error_message)));
+        return new Response($error_code, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode($error_message)));
     }
 }

--- a/test/Unit/Authentication/TokenMemoryCacheStorageTest.php
+++ b/test/Unit/Authentication/TokenMemoryCacheStorageTest.php
@@ -29,7 +29,7 @@ class TokenMemoryCacheStorageTest extends TestCase
     protected function setUp() : void
     {
         parent::setUp();
-        AnnotationRegistry::registerLoader('class_exists');
+
         $this->serializer = SerializerBuilder::create()->build();
         $this->token = new TokenMemoryCacheStorage();
     }

--- a/test/Unit/ClientTest.php
+++ b/test/Unit/ClientTest.php
@@ -5,6 +5,9 @@ namespace zaporylie\Vipps\Tests\Unit;
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface as HttpClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use zaporylie\Vipps\Authentication\TokenMemoryCacheStorage;
 use zaporylie\Vipps\Authentication\TokenStorageInterface;
 use zaporylie\Vipps\Client;
@@ -74,19 +77,19 @@ class ClientTest extends TestCase
      */
     public function testHttpClient()
     {
-        $this->assertInstanceOf(HttpClient::class, $this->client->getHttpClient());
-        $httpClient = $this->createMock(HttpClient::class);
+        $this->assertInstanceOf(HttpClientInterface::class, $this->client->getHttpClient());
+        $httpClient = $this->createMock(HttpClientInterface::class);
         $this->assertInstanceOf(Client::class, $this->client->setHttpClient($httpClient));
-        $this->expectException(\LogicException::class);
+        $this->expectError();
         $this->client->setHttpClient('');
     }
 
     /**
-     * @covers \zaporylie\Vipps\Client::getMessageFactory()
+     * @covers \zaporylie\Vipps\Client::getRequestFactory()
      */
     public function testGetMessageFactory()
     {
-        $this->assertInstanceOf(MessageFactory::class, $this->client->getMessageFactory());
+        $this->assertInstanceOf(RequestFactoryInterface::class, $this->client->getRequestFactory());
     }
 
     /**
@@ -96,12 +99,12 @@ class ClientTest extends TestCase
     {
         $client = new Client('test_client_id', [
             'endpoint' => 'test',
-            'http_client' => $this->createMock(HttpClient::class),
+            'http_client' => $this->createMock(HttpClientInterface::class),
         ]);
         $this->assertEquals('test_client_id', $client->getClientId());
         $this->assertEquals('test', $client->getEndpoint());
         $this->assertInstanceOf(TokenMemoryCacheStorage::class, $client->getTokenStorage());
-        $this->assertInstanceOf(HttpClient::class, $client->getHttpClient());
+        $this->assertInstanceOf(HttpClientInterface::class, $client->getHttpClient());
 
 
         $client = new Client('test_client_id', [

--- a/test/Unit/Model/Error/AuthorizationErrorTest.php
+++ b/test/Unit/Model/Error/AuthorizationErrorTest.php
@@ -22,7 +22,7 @@ class AuthorizationErrorTest extends ModelTestBase
     public function setUp() : void
     {
         parent::setUp();
-        AnnotationRegistry::registerLoader('class_exists');
+
         $serializer = SerializerBuilder::create()->build();
         $this->response = $serializer->deserialize(
             json_encode([

--- a/test/Unit/Model/Error/PaymentErrorTest.php
+++ b/test/Unit/Model/Error/PaymentErrorTest.php
@@ -21,7 +21,7 @@ class PaymentErrorTest extends ModelTestBase
     public function setUp() : void
     {
         parent::setUp();
-        AnnotationRegistry::registerLoader('class_exists');
+
         $serializer = SerializerBuilder::create()->build();
         $this->response = $serializer->deserialize(
             json_encode([

--- a/test/Unit/Resource/Authorization/GetTokenTest.php
+++ b/test/Unit/Resource/Authorization/GetTokenTest.php
@@ -3,7 +3,6 @@
 namespace zaporylie\Vipps\Tests\Unit\Resource\Authorization;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use zaporylie\Vipps\Model\Authorization\ResponseGetToken;
 use zaporylie\Vipps\Resource\Authorization\GetToken;
 use zaporylie\Vipps\Resource\HttpMethod;
@@ -29,7 +28,7 @@ class GetTokenTest extends ResourceTestBase
         $this->resource
             ->expects($this->any())
             ->method('makeCall')
-            ->will($this->returnValue(new Response(200, [], stream_for(json_encode([])))));
+            ->will($this->returnValue(new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode([])))));
     }
 
     /**

--- a/test/Unit/Resource/Payment/CancelPaymentTest.php
+++ b/test/Unit/Resource/Payment/CancelPaymentTest.php
@@ -3,7 +3,6 @@
 namespace zaporylie\Vipps\Tests\Unit\Resource\Payment;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use zaporylie\Vipps\Model\Payment\RequestCancelPayment;
 use zaporylie\Vipps\Model\Payment\ResponseCancelPayment;
 use zaporylie\Vipps\Resource\Payment\CancelPayment;
@@ -32,7 +31,7 @@ class CancelPaymentTest extends PaymentResourceBaseTestBase
         $this->resource
             ->expects($this->any())
             ->method('makeCall')
-            ->will($this->returnValue(new Response(200, [], stream_for(json_encode([])))));
+            ->will($this->returnValue(new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode([])))));
     }
 
     /**

--- a/test/Unit/Resource/Payment/CapturePaymentTest.php
+++ b/test/Unit/Resource/Payment/CapturePaymentTest.php
@@ -3,7 +3,6 @@
 namespace zaporylie\Vipps\Tests\Unit\Resource\Payment;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use zaporylie\Vipps\Model\Payment\RequestCapturePayment;
 use zaporylie\Vipps\Model\Payment\ResponseCapturePayment;
 use zaporylie\Vipps\Resource\Payment\CapturePayment;
@@ -32,7 +31,7 @@ class CapturePaymentTest extends PaymentResourceBaseTestBase
         $this->resource
             ->expects($this->any())
             ->method('makeCall')
-            ->will($this->returnValue(new Response(200, [], stream_for(json_encode([])))));
+            ->will($this->returnValue(new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode([])))));
     }
 
     /**

--- a/test/Unit/Resource/Payment/GetOrderStatusTest.php
+++ b/test/Unit/Resource/Payment/GetOrderStatusTest.php
@@ -3,7 +3,6 @@
 namespace zaporylie\Vipps\Tests\Unit\Resource\Payment;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use zaporylie\Vipps\Model\Payment\ResponseGetOrderStatus;
 use zaporylie\Vipps\Resource\Payment\GetOrderStatus;
 use zaporylie\Vipps\Resource\HttpMethod;
@@ -35,7 +34,7 @@ class GetOrderStatusTest extends PaymentResourceBaseTestBase
         $this->resource
             ->expects($this->any())
             ->method('makeCall')
-            ->will($this->returnValue(new Response(200, [], stream_for(json_encode([])))));
+            ->will($this->returnValue(new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode([])))));
     }
 
     /**

--- a/test/Unit/Resource/Payment/GetPaymentDetailsTest.php
+++ b/test/Unit/Resource/Payment/GetPaymentDetailsTest.php
@@ -3,7 +3,6 @@
 namespace zaporylie\Vipps\Tests\Unit\Resource\Payment;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use zaporylie\Vipps\Model\Payment\ResponseGetPaymentDetails;
 use zaporylie\Vipps\Resource\Payment\GetPaymentDetails;
 use zaporylie\Vipps\Resource\HttpMethod;
@@ -35,7 +34,7 @@ class GetPaymentDetailsTest extends PaymentResourceBaseTestBase
         $this->resource
             ->expects($this->any())
             ->method('makeCall')
-            ->will($this->returnValue(new Response(200, [], stream_for(json_encode([])))));
+            ->will($this->returnValue(new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode([])))));
     }
 
     /**

--- a/test/Unit/Resource/Payment/InitiatePaymentTest.php
+++ b/test/Unit/Resource/Payment/InitiatePaymentTest.php
@@ -3,7 +3,6 @@
 namespace zaporylie\Vipps\Tests\Unit\Resource\Payment;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use zaporylie\Vipps\Model\Payment\RequestInitiatePayment;
 use zaporylie\Vipps\Model\Payment\ResponseInitiatePayment;
 use zaporylie\Vipps\Resource\Payment\InitiatePayment;
@@ -32,7 +31,7 @@ class InitiatePaymentTest extends PaymentResourceBaseTestBase
         $this->resource
             ->expects($this->any())
             ->method('makeCall')
-            ->will($this->returnValue(new Response(200, [], stream_for(json_encode([])))));
+            ->will($this->returnValue(new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode([])))));
     }
 
     /**

--- a/test/Unit/Resource/Payment/RefundPaymentTest.php
+++ b/test/Unit/Resource/Payment/RefundPaymentTest.php
@@ -3,7 +3,6 @@
 namespace zaporylie\Vipps\Tests\Unit\Resource\Payment;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
 use zaporylie\Vipps\Model\Payment\RequestRefundPayment;
 use zaporylie\Vipps\Model\Payment\ResponseRefundPayment;
 use zaporylie\Vipps\Resource\Payment\RefundPayment;
@@ -32,7 +31,7 @@ class RefundPaymentTest extends PaymentResourceBaseTestBase
         $this->resource
             ->expects($this->any())
             ->method('makeCall')
-            ->will($this->returnValue(new Response(200, [], stream_for(json_encode([])))));
+            ->will($this->returnValue(new Response(200, [], \GuzzleHttp\Psr7\Utils::streamFor(json_encode([])))));
     }
 
     /**

--- a/test/Unit/Resource/ResourceBaseTest.php
+++ b/test/Unit/Resource/ResourceBaseTest.php
@@ -4,10 +4,8 @@ namespace zaporylie\Vipps\Tests\Unit\Resource;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Utils;
 use Http\Client\Exception\HttpException;
-use Http\Client\HttpAsyncClient;
-use Http\Promise\FulfilledPromise;
 use JMS\Serializer\Serializer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -153,7 +151,7 @@ class ResourceBaseTest extends ResourceTestBase
      */
     public function testHttpSuccess()
     {
-        $response = new Response(200, [], stream_for(json_encode([])));
+        $response = new Response(200, [], Utils::streamFor(json_encode([])));
         $this->httpClient
             ->expects($this->any())
             ->method('sendRequest')
@@ -164,16 +162,6 @@ class ResourceBaseTest extends ResourceTestBase
         $makeCall->setAccessible(true);
 
         // Test HttpClient.
-        $this->assertInstanceOf(ResponseInterface::class, $makeCall->invoke($this->resourceBase));
-
-        // Test HttpAsyncClient.
-        $this->httpClient = $this->createMock(HttpAsyncClient::class);
-        $this->vipps->getClient()->setHttpClient($this->httpClient);
-        $this->httpClient
-            ->expects($this->any())
-            ->method('sendAsyncRequest')
-            ->will($this->returnValue(new FulfilledPromise($response)));
-
         $this->assertInstanceOf(ResponseInterface::class, $makeCall->invoke($this->resourceBase));
     }
 

--- a/test/Unit/Resource/ResourceTestBase.php
+++ b/test/Unit/Resource/ResourceTestBase.php
@@ -4,6 +4,7 @@ namespace zaporylie\Vipps\Tests\Unit\Resource;
 
 use Http\Client\HttpClient;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use zaporylie\Vipps\Client;
 use zaporylie\Vipps\Tests\Unit\Authentication\TestTokenStorage;
 use zaporylie\Vipps\Vipps;
@@ -32,7 +33,7 @@ abstract class ResourceTestBase extends TestCase
     protected function setUp() : void
     {
         parent::setUp();
-        $this->httpClient = $this->createMock(HttpClient::class);
+        $this->httpClient = $this->createMock(ClientInterface::class);
         $this->client = new Client('test_client_id', [
             'http_client' => $this->httpClient,
             'token_storage' => new TestTokenStorage(),


### PR DESCRIPTION
This will likely be a breaking change, therefore, aiming for 3.x. At the same time, some other changes to the structure will be done.