### PR TITLE
Drop support for PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
+          - "8.2"
         composer-version:
           - "2"
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - 2.x
+      - 3.x
   pull_request:
     branches:
-      - 2.x
+      - 3.x
 
 jobs:
   test:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "keywords": ["payment"],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "psr/http-message": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "php-http/message": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": ["payment"],
     "require": {
         "php": "^7.4 || ^8.0",
+        "ext-json": "*",
         "psr/http-message": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "php-http/message": "^1.6",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,12 @@ parameters:
         - src
         - test
     ignoreErrors:
+        # Ignore Call to an undefined static method zaporylie\Vipps\Resource\HttpMethod::POST().
+        - '#Call to an undefined static method zaporylie\\Vipps\\Resource\\HttpMethod::POST\(\)#'
+        - '#Call to an undefined static method zaporylie\\Vipps\\Resource\\HttpMethod::PUT\(\)#'
+        - '#Call to an undefined static method zaporylie\\Vipps\\Resource\\HttpMethod::PATCH\(\)#'
+        - '#Call to an undefined static method zaporylie\\Vipps\\Resource\\HttpMethod::DELETE\(\)#'
+        - '#Call to an undefined static method zaporylie\\Vipps\\Resource\\HttpMethod::GET\(\)#'
 
 includes:
 	- phpstan-baseline.neon

--- a/src/Api/ApiBase.php
+++ b/src/Api/ApiBase.php
@@ -11,12 +11,12 @@ abstract class ApiBase
     /**
      * @var \zaporylie\Vipps\VippsInterface
      */
-    protected $app;
+    protected VippsInterface $app;
 
     /**
      * @var string
      */
-    protected $subscriptionKey;
+    protected string $subscriptionKey;
 
     /**
      * ApiBase constructor.
@@ -24,7 +24,7 @@ abstract class ApiBase
      * @param \zaporylie\Vipps\VippsInterface $app
      * @param string $subscription_key
      */
-    public function __construct(VippsInterface $app, $subscription_key)
+    public function __construct(VippsInterface $app, string $subscription_key)
     {
         $this->app = $app;
         $this->subscriptionKey = $subscription_key;
@@ -35,7 +35,7 @@ abstract class ApiBase
      *
      * @return string
      */
-    public function getSubscriptionKey()
+    public function getSubscriptionKey(): string
     {
         if (empty($this->subscriptionKey)) {
             throw new InvalidArgumentException('Missing subscription key');
@@ -50,7 +50,7 @@ abstract class ApiBase
      *
      * @return $this
      */
-    public function setSubscriptionKey($subscriptionKey)
+    public function setSubscriptionKey(string $subscriptionKey): self
     {
         $this->subscriptionKey = $subscriptionKey;
         return $this;

--- a/src/Api/Authorization.php
+++ b/src/Api/Authorization.php
@@ -2,6 +2,7 @@
 
 namespace zaporylie\Vipps\Api;
 
+use zaporylie\Vipps\Model\Authorization\ResponseGetToken;
 use zaporylie\Vipps\Resource\Authorization\GetToken;
 
 class Authorization extends ApiBase implements AuthorizationInterface
@@ -9,10 +10,8 @@ class Authorization extends ApiBase implements AuthorizationInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return \zaporylie\Vipps\Model\Authorization\ResponseGetToken
      */
-    public function getToken($client_secret)
+    public function getToken($client_secret): ResponseGetToken
     {
         // Initiate GetToken resource.
         $resource = new GetToken($this->app, $this->getSubscriptionKey(), $client_secret);

--- a/src/Api/AuthorizationInterface.php
+++ b/src/Api/AuthorizationInterface.php
@@ -8,6 +8,8 @@
 
 namespace zaporylie\Vipps\Api;
 
+use zaporylie\Vipps\Model\Authorization\ResponseGetToken;
+
 interface AuthorizationInterface
 {
 
@@ -16,5 +18,5 @@ interface AuthorizationInterface
      *
      * @return \zaporylie\Vipps\Model\Authorization\ResponseGetToken
      */
-    public function getToken($client_secret);
+    public function getToken(string $client_secret): ResponseGetToken;
 }

--- a/src/Api/Payment.php
+++ b/src/Api/Payment.php
@@ -2,6 +2,7 @@
 
 namespace zaporylie\Vipps\Api;
 
+use http\Env\Response;
 use zaporylie\Vipps\Exceptions\Api\InvalidArgumentException;
 use zaporylie\Vipps\Model\Payment\CustomerInfo;
 use zaporylie\Vipps\Model\Payment\MerchantInfo;
@@ -9,6 +10,12 @@ use zaporylie\Vipps\Model\Payment\RequestCancelPayment;
 use zaporylie\Vipps\Model\Payment\RequestCapturePayment;
 use zaporylie\Vipps\Model\Payment\RequestInitiatePayment;
 use zaporylie\Vipps\Model\Payment\RequestRefundPayment;
+use zaporylie\Vipps\Model\Payment\ResponseCancelPayment;
+use zaporylie\Vipps\Model\Payment\ResponseCapturePayment;
+use zaporylie\Vipps\Model\Payment\ResponseGetOrderStatus;
+use zaporylie\Vipps\Model\Payment\ResponseGetPaymentDetails;
+use zaporylie\Vipps\Model\Payment\ResponseInitiatePayment;
+use zaporylie\Vipps\Model\Payment\ResponseRefundPayment;
 use zaporylie\Vipps\Model\Payment\Transaction;
 use zaporylie\Vipps\Resource\Payment\CancelPayment;
 use zaporylie\Vipps\Resource\Payment\CapturePayment;
@@ -29,19 +36,19 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * @var string
      */
-    protected $merchantSerialNumber;
+    protected string $merchantSerialNumber;
 
     /**
      * @var string
      */
-    protected $customPath;
+    protected string $customPath;
 
     /**
      * Gets merchantSerialNumber value.
      *
      * @return string
      */
-    public function getMerchantSerialNumber()
+    public function getMerchantSerialNumber(): string
     {
         if (empty($this->merchantSerialNumber)) {
             throw new InvalidArgumentException('Missing merchant serial number');
@@ -52,7 +59,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * @return string
      */
-    public function getCustomPath()
+    public function getCustomPath(): string
     {
         return $this->customPath;
     }
@@ -69,9 +76,9 @@ class Payment extends ApiBase implements PaymentInterface
      */
     public function __construct(
         VippsInterface $app,
-        $subscription_key,
-        $merchant_serial_number,
-        $custom_path = 'ecomm'
+        string $subscription_key,
+        string $merchant_serial_number,
+        string $custom_path = 'ecomm'
     ) {
         parent::__construct($app, $subscription_key);
         $this->merchantSerialNumber = $merchant_serial_number;
@@ -81,7 +88,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function cancelPayment($order_id, $text)
+    public function cancelPayment(string $order_id, string $text): ResponseCancelPayment
     {
         // Build request object from data passed to method.
         $request = (new RequestCancelPayment())
@@ -103,7 +110,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function capturePayment($order_id, $text, $amount = 0)
+    public function capturePayment(string $order_id, string $text, int $amount = 0): ResponseCapturePayment
     {
         // Build request object from data passed to method.
         $request = (new RequestCapturePayment())
@@ -129,7 +136,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function getOrderStatus($order_id)
+    public function getOrderStatus(string $order_id): ResponseGetOrderStatus
     {
         // Get order status.
         // this is GET request so no need to create request object.
@@ -147,7 +154,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function getPaymentDetails($order_id)
+    public function getPaymentDetails(string $order_id): ResponseGetPaymentDetails
     {
         // Get payment details.
         // this is GET request so no need to create request object.
@@ -166,13 +173,13 @@ class Payment extends ApiBase implements PaymentInterface
      * {@inheritdoc}
      */
     public function initiatePayment(
-        $order_id,
-        $amount,
-        $text,
-        $callbackPrefix,
-        $fallback,
-        $options = []
-    ) {
+        string $order_id,
+        int $amount,
+        string $text,
+        string $callbackPrefix,
+        string $fallback,
+        array $options = []
+    ): ResponseInitiatePayment {
         // Create Request object based on data passed to this method.
         $request = (new RequestInitiatePayment())
             ->setCustomerInfo(
@@ -232,7 +239,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function refundPayment($order_id, $text, $amount = 0)
+    public function refundPayment(string $order_id, string $text, int $amount = 0): ResponseRefundPayment
     {
         // Prepare request object based on data passed to method.
         $request = (new RequestRefundPayment())

--- a/src/Api/PaymentInterface.php
+++ b/src/Api/PaymentInterface.php
@@ -2,6 +2,13 @@
 
 namespace zaporylie\Vipps\Api;
 
+use zaporylie\Vipps\Model\Payment\ResponseCancelPayment;
+use zaporylie\Vipps\Model\Payment\ResponseCapturePayment;
+use zaporylie\Vipps\Model\Payment\ResponseGetOrderStatus;
+use zaporylie\Vipps\Model\Payment\ResponseGetPaymentDetails;
+use zaporylie\Vipps\Model\Payment\ResponseInitiatePayment;
+use zaporylie\Vipps\Model\Payment\ResponseRefundPayment;
+
 /**
  * Interface PaymentInterface
  *
@@ -16,7 +23,7 @@ interface PaymentInterface
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseCancelPayment
      */
-    public function cancelPayment($order_id, $text);
+    public function cancelPayment(string $order_id, string $text): ResponseCancelPayment;
 
     /**
      * @param string $order_id
@@ -25,7 +32,7 @@ interface PaymentInterface
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseCapturePayment
      */
-    public function capturePayment($order_id, $text, $amount = 0);
+    public function capturePayment(string $order_id, string $text, int $amount = 0): ResponseCapturePayment;
 
     /**
      * @param string $order_id
@@ -35,14 +42,14 @@ interface PaymentInterface
      * @deprecated Get order status was deprecated and can be removed in version 3.0.
      * @see \zaporylie\Vipps\Resource\Payment\GetOrderStatus
      */
-    public function getOrderStatus($order_id);
+    public function getOrderStatus(string $order_id): ResponseGetOrderStatus;
 
     /**
      * @param string $order_id
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseGetPaymentDetails
      */
-    public function getPaymentDetails($order_id);
+    public function getPaymentDetails(string $order_id): ResponseGetPaymentDetails;
 
     /**
      * @param string $order_id
@@ -50,14 +57,14 @@ interface PaymentInterface
      * @param string $text
      * @param string $callbackPrefix
      * @param string $fallback
-     * @param $options array
+     * @param array $options
      *   Optional values.
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseInitiatePayment
      *
      * @see https://vippsas.github.io/vipps-ecom-api/#/Vipps_eCom_API/initiatePaymentV3UsingPOST
      */
-    public function initiatePayment($order_id, $amount, $text, $callbackPrefix, $fallback, $options = []);
+    public function initiatePayment(string $order_id, int $amount, string $text, string $callbackPrefix, string $fallback, array $options = []): ResponseInitiatePayment;
 
     /**
      * @param string $order_id
@@ -66,5 +73,5 @@ interface PaymentInterface
      *
      * @return \zaporylie\Vipps\Model\Payment\ResponseRefundPayment
      */
-    public function refundPayment($order_id, $text, $amount = 0);
+    public function refundPayment(string $order_id, string $text, int $amount = 0): ResponseRefundPayment;
 }

--- a/src/Api/RecurringPayment.php
+++ b/src/Api/RecurringPayment.php
@@ -3,10 +3,15 @@
 namespace zaporylie\Vipps\Api;
 
 use zaporylie\Vipps\Exceptions\Api\InvalidArgumentException;
+use zaporylie\Vipps\Model\RecurringPayment\Charge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestRefundCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseCreateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseCreateCharge;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseUpdateAgreement;
 use zaporylie\Vipps\Resource\RecurringPayment\CancelCharge;
 use zaporylie\Vipps\Resource\RecurringPayment\CaptureCharge;
 use zaporylie\Vipps\Resource\RecurringPayment\CreateAgreement;
@@ -52,13 +57,13 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
      *
      * @param \zaporylie\Vipps\VippsInterface $app
      * @param string $subscription_key
-     * @param $merchant_serial_number
-     * @param $custom_path
+     * @param string $merchant_serial_number
+     * @param string $custom_path
      */
     public function __construct(
         VippsInterface $app,
-        $subscription_key,
-        $merchant_serial_number
+        string $subscription_key,
+        string $merchant_serial_number
     ) {
         parent::__construct($app, $subscription_key);
         $this->merchantSerialNumber = $merchant_serial_number;
@@ -67,7 +72,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function createAgreement(RequestCreateAgreement $request)
+    public function createAgreement(RequestCreateAgreement $request): ResponseCreateAgreement
     {
         $resource = new CreateAgreement($this->app, $this->getSubscriptionKey(), $request);
         $response = $resource->call();
@@ -77,7 +82,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function getAgreements()
+    public function getAgreements(): array
     {
         $resource = new GetAgreements($this->app, $this->getSubscriptionKey());
         $response = $resource->call();
@@ -87,7 +92,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function getAgreement($agreement_id)
+    public function getAgreement(string $agreement_id): ResponseGetAgreement
     {
         $resource = new GetAgreement($this->app, $this->getSubscriptionKey(), $agreement_id);
         $response = $resource->call();
@@ -97,7 +102,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function updateAgreement($agreement_id, RequestUpdateAgreement $request)
+    public function updateAgreement(string $agreement_id, RequestUpdateAgreement $request): ResponseUpdateAgreement
     {
         $resource = new UpdateAgreement($this->app, $this->getSubscriptionKey(), $agreement_id, $request);
         $response = $resource->call();
@@ -107,7 +112,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritDoc}
      */
-    public function getCharges($agreement_id)
+    public function getCharges(string $agreement_id): array
     {
         $resource = new GetCharges($this->app, $this->getSubscriptionKey(), $agreement_id);
         $response = $resource->call();
@@ -117,7 +122,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritDoc}
      */
-    public function getCharge($agreement_id, $charge_id)
+    public function getCharge(string $agreement_id, $charge_id): Charge
     {
         $resource = new GetCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $charge_id);
         $response = $resource->call();
@@ -127,7 +132,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritDoc}
      */
-    public function createCharge($agreement_id, RequestCreateCharge $request)
+    public function createCharge(string $agreement_id, RequestCreateCharge $request): ResponseCreateCharge
     {
         $resource = new CreateCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $request);
         $response = $resource->call();
@@ -137,7 +142,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritDoc}
      */
-    public function cancelCharge($agreement_id, $charge_id)
+    public function cancelCharge($agreement_id, $charge_id): string
     {
         $resource = new CancelCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $charge_id);
         $response = $resource->call();
@@ -147,7 +152,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritDoc}
      */
-    public function captureCharge($agreement_id, $charge_id)
+    public function captureCharge($agreement_id, $charge_id): string
     {
         $resource = new CaptureCharge($this->app, $this->getSubscriptionKey(), $agreement_id, $charge_id);
         $response = $resource->call();
@@ -157,7 +162,7 @@ class RecurringPayment extends ApiBase implements RecurringPaymentInterface
     /**
      * {@inheritDoc}
      */
-    public function refundCharge($agreement_id, $charge_id, RequestRefundCharge $requestObject)
+    public function refundCharge($agreement_id, $charge_id, RequestRefundCharge $requestObject): string
     {
         $resource = new RefundCharge(
             $this->app,

--- a/src/Api/RecurringPaymentInterface.php
+++ b/src/Api/RecurringPaymentInterface.php
@@ -2,10 +2,15 @@
 
 namespace zaporylie\Vipps\Api;
 
+use zaporylie\Vipps\Model\RecurringPayment\Charge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateAgreement;
 use zaporylie\Vipps\Model\RecurringPayment\RequestCreateCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestRefundCharge;
 use zaporylie\Vipps\Model\RecurringPayment\RequestUpdateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseCreateAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseCreateCharge;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement;
+use zaporylie\Vipps\Model\RecurringPayment\ResponseUpdateAgreement;
 
 /**
  * Interface PaymentInterface
@@ -20,17 +25,17 @@ interface RecurringPaymentInterface
      *
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseCreateAgreement
      */
-    public function createAgreement(RequestCreateAgreement $requestCreateAgreement);
+    public function createAgreement(RequestCreateAgreement $requestCreateAgreement): ResponseCreateAgreement;
 
     /**
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement[]
      */
-    public function getAgreements();
+    public function getAgreements(): array;
 
     /**
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement
      */
-    public function getAgreement($agreement_id);
+    public function getAgreement(string $agreement_id): ResponseGetAgreement;
 
     /**
      * @param $agreement_id
@@ -38,14 +43,14 @@ interface RecurringPaymentInterface
      *
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseUpdateAgreement
      */
-    public function updateAgreement($agreement_id, RequestUpdateAgreement $request);
+    public function updateAgreement(string $agreement_id, RequestUpdateAgreement $request): ResponseUpdateAgreement;
 
     /**
      * @param $agreement_id
      *
      * @return \zaporylie\Vipps\Model\RecurringPayment\Charge[]
      */
-    public function getCharges($agreement_id);
+    public function getCharges(string $agreement_id): array;
 
     /**
      * @param $agreement_id
@@ -53,7 +58,7 @@ interface RecurringPaymentInterface
      *
      * @return \zaporylie\Vipps\Model\RecurringPayment\Charge
      */
-    public function getCharge($agreement_id, $charge_id);
+    public function getCharge(string $agreement_id, string $charge_id): Charge;
 
     /**
      * @param $agreement_id
@@ -61,7 +66,7 @@ interface RecurringPaymentInterface
      *
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseCreateCharge
      */
-    public function createCharge($agreement_id, RequestCreateCharge $request);
+    public function createCharge(string $agreement_id, RequestCreateCharge $request): ResponseCreateCharge;
 
     /**
      * @param string $agreement_id
@@ -69,7 +74,7 @@ interface RecurringPaymentInterface
      *
      * @return string
      */
-    public function cancelCharge($agreement_id, $charge_id);
+    public function cancelCharge(string $agreement_id, string $charge_id): string;
 
     /**
      * @param string $agreement_id
@@ -77,7 +82,7 @@ interface RecurringPaymentInterface
      *
      * @return string
      */
-    public function captureCharge($agreement_id, $charge_id);
+    public function captureCharge(string $agreement_id, string $charge_id): string;
 
     /**
      * @param string $agreement_id
@@ -86,5 +91,5 @@ interface RecurringPaymentInterface
      *
      * @return string
      */
-    public function refundCharge($agreement_id, $charge_id, RequestRefundCharge $requestObject);
+    public function refundCharge(string $agreement_id, string $charge_id, RequestRefundCharge $requestObject): string;
 }

--- a/src/Api/UserInfo.php
+++ b/src/Api/UserInfo.php
@@ -2,6 +2,7 @@
 
 namespace zaporylie\Vipps\Api;
 
+use zaporylie\Vipps\Model\UserInfo\ResponseUserInfo;
 use zaporylie\Vipps\Resource\UserInfo\UserInfo as UserInfoResource;
 use zaporylie\Vipps\VippsInterface;
 
@@ -26,7 +27,7 @@ class UserInfo extends ApiBase implements UserInfoInterface
     /**
      * {@inheritdoc}
      */
-    public function userInfo($sub)
+    public function userInfo(string $sub): ResponseUserInfo
     {
         $resource = new UserInfoResource($this->app, $sub);
         /** @var \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo $response */

--- a/src/Api/UserInfoInterface.php
+++ b/src/Api/UserInfoInterface.php
@@ -2,6 +2,8 @@
 
 namespace zaporylie\Vipps\Api;
 
+use zaporylie\Vipps\Model\UserInfo\ResponseUserInfo;
+
 /**
  * Interface UserInfoInterface
  *
@@ -15,5 +17,5 @@ interface UserInfoInterface
      *
      * @return \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo
      */
-    public function userInfo($sub);
+    public function userInfo(string $sub): ResponseUserInfo;
 }

--- a/src/Authentication/TokenMemoryCacheStorage.php
+++ b/src/Authentication/TokenMemoryCacheStorage.php
@@ -21,7 +21,7 @@ class TokenMemoryCacheStorage implements TokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function get()
+    public function get(): ResponseGetToken
     {
         if (!$this->has()) {
             throw new InvalidArgumentException('Missing Token');
@@ -32,7 +32,7 @@ class TokenMemoryCacheStorage implements TokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function set(ResponseGetToken $token)
+    public function set(ResponseGetToken $token): TokenStorageInterface
     {
         $this->token = $token;
         return $this;
@@ -41,7 +41,7 @@ class TokenMemoryCacheStorage implements TokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function has()
+    public function has(): bool
     {
         if (!($this->token instanceof ResponseGetToken)) {
             return false;
@@ -58,7 +58,7 @@ class TokenMemoryCacheStorage implements TokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function delete()
+    public function delete(): TokenStorageInterface
     {
         $this->token = null;
         return $this;
@@ -67,7 +67,7 @@ class TokenMemoryCacheStorage implements TokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function clear()
+    public function clear(): TokenStorageInterface
     {
         $this->delete();
         return $this;

--- a/src/Authentication/TokenStorageInterface.php
+++ b/src/Authentication/TokenStorageInterface.php
@@ -16,27 +16,27 @@ interface TokenStorageInterface
      * @return \zaporylie\Vipps\Model\Authorization\ResponseGetToken
      * @throws \zaporylie\Vipps\Exceptions\Authentication\InvalidArgumentException
      */
-    public function get();
+    public function get() : ResponseGetToken;
 
     /**
      * @param \zaporylie\Vipps\Model\Authorization\ResponseGetToken $token
      *
      * @return self
      */
-    public function set(ResponseGetToken $token);
+    public function set(ResponseGetToken $token): self;
 
     /**
      * @return bool
      */
-    public function has();
+    public function has(): bool;
 
     /**
      * @return self
      */
-    public function delete();
+    public function delete(): self;
 
     /**
      * @return self
      */
-    public function clear();
+    public function clear(): self;
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,37 +20,37 @@ class Client implements ClientInterface
     /**
      * @var \Psr\Http\Client\ClientInterface
      */
-    protected $httpClient;
+    protected HttpClientInterface $httpClient;
 
     /**
      * @var \zaporylie\Vipps\EndpointInterface
      */
-    protected $endpoint;
+    protected EndpointInterface $endpoint;
 
     /**
      * @var \Psr\Http\Message\RequestFactoryInterface
      */
-    protected $requestFactory;
+    protected RequestFactoryInterface $requestFactory;
 
     /**
      * @var string
      */
-    protected $token;
+    protected string $token;
 
     /**
      * @var string
      */
-    protected $tokenType;
+    protected string $tokenType;
 
     /**
      * @var \zaporylie\Vipps\Authentication\TokenStorageInterface
      */
-    protected $tokenStorage;
+    protected TokenStorageInterface $tokenStorage;
 
     /**
      * @var string
      */
-    protected $clientId;
+    protected string $clientId;
 
     /**
      * VippsClient constructor.
@@ -90,7 +90,7 @@ class Client implements ClientInterface
      *
      * @return string
      */
-    public function getToken()
+    public function getToken(): string
     {
         if (!isset($this->token)) {
             throw new InvalidArgumentException('Missing Token');
@@ -99,34 +99,26 @@ class Client implements ClientInterface
     }
 
     /**
-     * Gets tokenStorage value.
-     *
-     * @return \zaporylie\Vipps\Authentication\TokenStorageInterface
+     * {inheritdoc}
      */
-    public function getTokenStorage()
+    public function getTokenStorage(): TokenStorageInterface
     {
         return $this->tokenStorage;
     }
 
     /**
-     * Sets tokenStorage variable.
-     *
-     * @param \zaporylie\Vipps\Authentication\TokenStorageInterface $tokenStorage
-     *
-     * @return $this
+     * {inheritdoc}
      */
-    public function setTokenStorage(TokenStorageInterface $tokenStorage)
+    public function setTokenStorage(TokenStorageInterface $tokenStorage): self
     {
         $this->tokenStorage = $tokenStorage;
         return $this;
     }
 
     /**
-     * Gets clientId value.
-     *
-     * @return string
+     * {inheritdoc}
      */
-    public function getClientId()
+    public function getClientId(): string
     {
         if (!isset($this->clientId)) {
             throw new InvalidArgumentException('Missing Client ID');
@@ -135,13 +127,9 @@ class Client implements ClientInterface
     }
 
     /**
-     * Sets clientId variable.
-     *
-     * @param string $clientId
-     *
-     * @return $this
+     * {inheritdoc}
      */
-    public function setClientId($clientId)
+    public function setClientId(string $clientId): self
     {
         $this->clientId = $clientId;
         return $this;
@@ -158,7 +146,7 @@ class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function setEndpoint(EndpointInterface $endpoint)
+    public function setEndpoint(EndpointInterface $endpoint): self
     {
         $this->endpoint = $endpoint;
         return $this;
@@ -175,7 +163,7 @@ class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function setHttpClient(?HttpClientInterface $httpClient)
+    public function setHttpClient(?HttpClientInterface $httpClient): self
     {
         $this->httpClient = self::httpClientDiscovery($httpClient);
         unset($this->requestFactory);

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -11,21 +11,21 @@ interface ClientInterface
     /**
      * @return \zaporylie\Vipps\Authentication\TokenStorageInterface
      */
-    public function getTokenStorage();
+    public function getTokenStorage(): TokenStorageInterface;
 
     /**
      * @param \zaporylie\Vipps\Authentication\TokenStorageInterface $tokenStorage
      *
      * @return $this
      */
-    public function setTokenStorage(TokenStorageInterface $tokenStorage);
+    public function setTokenStorage(TokenStorageInterface $tokenStorage): self;
 
     /**
      * Gets clientId value.
      *
      * @return string
      */
-    public function getClientId();
+    public function getClientId(): string;
 
     /**
      * Sets clientId variable.
@@ -34,7 +34,7 @@ interface ClientInterface
      *
      * @return $this
      */
-    public function setClientId($clientId);
+    public function setClientId(string $clientId): self;
 
     /**
      * Gets connection value.
@@ -50,7 +50,7 @@ interface ClientInterface
      *
      * @return $this
      */
-    public function setEndpoint(EndpointInterface $endpoint);
+    public function setEndpoint(EndpointInterface $endpoint): self;
 
     /**
      * Gets httpClient value.

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -10,7 +10,7 @@ namespace zaporylie\Vipps;
 
 use Eloquent\Enumeration\AbstractMultiton;
 use Http\Discovery\Psr17FactoryDiscovery;
-use Http\Discovery\UriFactoryDiscovery;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Class ConnectionBase
@@ -34,10 +34,10 @@ class Endpoint extends AbstractMultiton implements EndpointInterface
         'path' => '',
     ];
 
-    protected $scheme;
-    protected $host;
-    protected $port;
-    protected $path;
+    protected string $scheme;
+    protected string $host;
+    protected string $port;
+    protected string $path;
 
     /**
      * {@inheritdoc}
@@ -66,51 +66,41 @@ class Endpoint extends AbstractMultiton implements EndpointInterface
     }
 
     /**
-     * Gets scheme value.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function getScheme()
+    public function getScheme(): string
     {
         return $this->scheme;
     }
 
     /**
-     * Gets host value.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
 
     /**
-     * Gets port value.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function getPort()
+    public function getPort(): string
     {
         return $this->port;
     }
 
     /**
-     * Gets path value.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
 
     /**
-     * Get connection base uri.
-     *
-     * @return \Psr\Http\Message\UriInterface
+     * {@inheritdoc}
      */
-    public function getUri()
+    public function getUri(): UriInterface
     {
         $uri = Psr17FactoryDiscovery::findUriFactory();
         return $uri->createUri(sprintf(

--- a/src/EndpointInterface.php
+++ b/src/EndpointInterface.php
@@ -8,8 +8,11 @@
 
 namespace zaporylie\Vipps;
 
+use Psr\Http\Message\UriInterface;
+
 /**
  * Interface ConnectionInterface
+ *
  * @package Vipps
  * @subpackage Connection
  */
@@ -19,27 +22,27 @@ interface EndpointInterface
     /**
      * @return string
      */
-    public function getScheme();
+    public function getScheme(): string;
 
     /**
      * @return string
      */
-    public function getHost();
+    public function getHost(): string;
 
     /**
      * @return string
      */
-    public function getPort();
+    public function getPort(): string;
 
     /**
      * @return string
      */
-    public function getPath();
+    public function getPath(): string;
 
     /**
      * Returns base URI for requests against VIPPS servers.
      *
      * @return \Psr\Http\Message\UriInterface
      */
-    public function getUri();
+    public function getUri(): UriInterface;
 }

--- a/src/Exceptions/VippsException.php
+++ b/src/Exceptions/VippsException.php
@@ -24,7 +24,7 @@ class VippsException extends \Exception
     /**
      * @var \zaporylie\Vipps\Model\Error\ErrorInterface|null
      */
-    protected $error;
+    protected ?ErrorInterface $error;
 
     /**
      * VippsException constructor.
@@ -34,7 +34,7 @@ class VippsException extends \Exception
      * @param \Exception|null $previous
      * @param \zaporylie\Vipps\Model\Error\ErrorInterface|null $error
      */
-    public function __construct($message = '', $code = 0, \Exception $previous = null, ErrorInterface $error = null)
+    public function __construct($message = '', $code = 0, \Exception $previous = null, ?ErrorInterface $error = null)
     {
         parent::__construct($message, $code, $previous);
         $this->error = $error;
@@ -99,7 +99,7 @@ class VippsException extends \Exception
         ResponseInterface $response,
         $serializer = null,
         $force = true
-    ) {
+    ): ?VippsException {
 
         // If error code tells us that something went wrong we must accept it.
         if (!$force && $response->getStatusCode() >= 400) {

--- a/src/Model/UserInfo/AccountInfo.php
+++ b/src/Model/UserInfo/AccountInfo.php
@@ -9,23 +9,53 @@ use JMS\Serializer\Annotation as Serializer;
  *
  * @package Vipps\Model\UserInfo
  */
-class AccountInfo
+final class AccountInfo
 {
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $account_name;
+    protected string $account_name;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $account_number;
+    protected string $account_number;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $bank_name;
+    protected string $bank_name;
+
+    /**
+     * Gets account_name value.
+     *
+     * @return string
+     */
+    public function getAccountName(): string
+    {
+        return $this->account_name;
+    }
+
+    /**
+     * Gets account_number value.
+     *
+     * @return string
+     */
+    public function getAccountNumber(): string
+    {
+        return $this->account_number;
+    }
+
+    /**
+     * Gets bank_name value.
+     *
+     * @return string
+     */
+    public function getBankName(): string
+    {
+        return $this->bank_name;
+    }
 }

--- a/src/Model/UserInfo/Address.php
+++ b/src/Model/UserInfo/Address.php
@@ -9,50 +9,50 @@ use JMS\Serializer\Annotation as Serializer;
  *
  * @package Vipps\Model\UserInfo
  */
-class Address
+final class Address
 {
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $address_type;
+    protected string $address_type;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $street_address;
+    protected string $street_address;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $region;
+    protected string $region;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $country;
+    protected string $country;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $postal_code;
+    protected string $postal_code;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $formatted;
+    protected string $formatted;
 
     /**
      * Gets address_type value.
      *
      * @return string
      */
-    public function getAddressType()
+    public function getAddressType(): string
     {
         return $this->address_type;
     }
@@ -62,7 +62,7 @@ class Address
      *
      * @return string
      */
-    public function getStreetAddress()
+    public function getStreetAddress(): string
     {
         return $this->street_address;
     }
@@ -72,7 +72,7 @@ class Address
      *
      * @return string
      */
-    public function getRegion()
+    public function getRegion(): string
     {
         return $this->region;
     }
@@ -82,7 +82,7 @@ class Address
      *
      * @return string
      */
-    public function getCountry()
+    public function getCountry(): string
     {
         return $this->country;
     }
@@ -92,7 +92,7 @@ class Address
      *
      * @return string
      */
-    public function getPostalCode()
+    public function getPostalCode(): string
     {
         return $this->postal_code;
     }
@@ -102,7 +102,7 @@ class Address
      *
      * @return string
      */
-    public function getFormatted()
+    public function getFormatted(): string
     {
         return $this->formatted;
     }

--- a/src/Model/UserInfo/ResponseUserInfo.php
+++ b/src/Model/UserInfo/ResponseUserInfo.php
@@ -4,92 +4,92 @@ namespace zaporylie\Vipps\Model\UserInfo;
 
 use JMS\Serializer\Annotation as Serializer;
 
-class ResponseUserInfo
+final class ResponseUserInfo
 {
     /**
      * @var \zaporylie\Vipps\Model\UserInfo\AccountInfo[]
      * @Serializer\Type("array<zaporylie\Vipps\Model\UserInfo\AccountInfo>")
      */
-    protected $accounts;
+    protected array $accounts;
 
     /**
      * @var \zaporylie\Vipps\Model\UserInfo\Address
      * @Serializer\Type("zaporylie\Vipps\Model\UserInfo\Address")
      */
-    protected $address;
+    protected Address $address;
 
     /**
      * @var \zaporylie\Vipps\Model\UserInfo\Address[]
      * @Serializer\Type("array<zaporylie\Vipps\Model\UserInfo\Address>")
      */
-    protected $other_addresses;
+    protected array $other_addresses;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $birthday;
+    protected string $birthdate;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $email;
+    protected string $email;
 
     /**
      * @var bool
      * @Serializer\Type("boolean")
      */
-    protected $email_verified;
+    protected bool $email_verified;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $family_name;
+    protected string $family_name;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $given_name;
+    protected string $given_name;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $name;
+    protected string $name;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $nin;
+    protected string $nin;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $phone_number;
+    protected string $phone_number;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $sid;
+    protected string $sid;
 
     /**
      * @var string
      * @Serializer\Type("string")
      */
-    protected $sub;
+    protected string $sub;
 
     /**
      * Gets accounts value.
      *
      * @return \zaporylie\Vipps\Model\UserInfo\AccountInfo[]
      */
-    public function getAccounts()
+    public function getAccounts(): array
     {
         return $this->accounts;
     }
@@ -99,19 +99,19 @@ class ResponseUserInfo
      *
      * @return \zaporylie\Vipps\Model\UserInfo\Address
      */
-    public function getAddress()
+    public function getAddress(): Address
     {
         return $this->address;
     }
 
     /**
-     * Gets birthday value.
+     * Gets birthdate value.
      *
      * @return string
      */
-    public function getBirthday()
+    public function getBirthdate(): string
     {
-        return $this->birthday;
+        return $this->birthdate;
     }
 
     /**
@@ -119,7 +119,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }
@@ -129,7 +129,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getFamilyName()
+    public function getFamilyName(): string
     {
         return $this->family_name;
     }
@@ -139,7 +139,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getGivenName()
+    public function getGivenName(): string
     {
         return $this->given_name;
     }
@@ -149,7 +149,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -159,7 +159,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getNin()
+    public function getNin(): string
     {
         return $this->nin;
     }
@@ -169,7 +169,7 @@ class ResponseUserInfo
      *
      * @return \zaporylie\Vipps\Model\UserInfo\Address[]
      */
-    public function getOtherAddresses()
+    public function getOtherAddresses(): array
     {
         return $this->other_addresses;
     }
@@ -179,7 +179,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getPhoneNumber()
+    public function getPhoneNumber(): string
     {
         return $this->phone_number;
     }
@@ -189,7 +189,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getSid()
+    public function getSid(): string
     {
         return $this->sid;
     }
@@ -199,7 +199,7 @@ class ResponseUserInfo
      *
      * @return string
      */
-    public function getSub()
+    public function getSub(): string
     {
         return $this->sub;
     }

--- a/src/Resource/Authorization/GetToken.php
+++ b/src/Resource/Authorization/GetToken.php
@@ -16,14 +16,9 @@ class GetToken extends ResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod;
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/accessToken/get';
+    protected string $path = '/accessToken/get';
 
     /**
      * GetToken constructor.
@@ -34,6 +29,7 @@ class GetToken extends ResourceBase
      */
     public function __construct(VippsInterface $vipps, $subscription_key, $client_secret)
     {
+        $this->method = HttpMethod::POST();
         parent::__construct($vipps, $subscription_key);
         // Authorization module requires client_id to be set on "client_id"
         // header.

--- a/src/Resource/IdempotencyKeyFactory.php
+++ b/src/Resource/IdempotencyKeyFactory.php
@@ -15,7 +15,7 @@ abstract class IdempotencyKeyFactory
      *
      * @return string
      */
-    public static function generate()
+    public static function generate(): string
     {
         return uniqid('', true);
     }

--- a/src/Resource/Payment/CancelPayment.php
+++ b/src/Resource/Payment/CancelPayment.php
@@ -16,14 +16,9 @@ class CancelPayment extends PaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::PUT;
-
-    /**
      * @var string
      */
-    protected $path = '/ecomm/v2/payments/{id}/cancel';
+    protected string $path = '/ecomm/v2/payments/{id}/cancel';
 
     /**
      * InitiatePayment constructor.
@@ -40,6 +35,7 @@ class CancelPayment extends PaymentResourceBase
         RequestCancelPayment $requestObject
     ) {
         parent::__construct($vipps, $subscription_key);
+        $this->method = HttpMethod::PUT();
         $this->body = $this
             ->getSerializer()
             ->serialize(

--- a/src/Resource/Payment/CapturePayment.php
+++ b/src/Resource/Payment/CapturePayment.php
@@ -16,14 +16,9 @@ class CapturePayment extends PaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/ecomm/v2/payments/{id}/capture';
+    protected string $path = '/ecomm/v2/payments/{id}/capture';
 
     /**
      * InitiatePayment constructor.
@@ -39,6 +34,7 @@ class CapturePayment extends PaymentResourceBase
         $order_id,
         RequestCapturePayment $requestObject
     ) {
+        $this->method = HttpMethod::POST();
         parent::__construct($vipps, $subscription_key);
         $this->body = $this
             ->getSerializer()

--- a/src/Resource/Payment/GetOrderStatus.php
+++ b/src/Resource/Payment/GetOrderStatus.php
@@ -18,14 +18,9 @@ class GetOrderStatus extends PaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::GET;
-
-    /**
      * @var string
      */
-    protected $path = '/ecomm/v2/payments/{id}/status';
+    protected string $path = '/ecomm/v2/payments/{id}/status';
 
     /**
      * InitiatePayment constructor.
@@ -36,6 +31,7 @@ class GetOrderStatus extends PaymentResourceBase
      */
     public function __construct(VippsInterface $vipps, $subscription_key, $order_id)
     {
+        $this->method = HttpMethod::GET();
         parent::__construct($vipps, $subscription_key);
         $this->id = $order_id;
     }

--- a/src/Resource/Payment/GetPaymentDetails.php
+++ b/src/Resource/Payment/GetPaymentDetails.php
@@ -10,14 +10,9 @@ class GetPaymentDetails extends PaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::GET;
-
-    /**
      * @var string
      */
-    protected $path = '/ecomm/v2/payments/{id}/details';
+    protected string $path = '/ecomm/v2/payments/{id}/details';
 
     /**
      * InitiatePayment constructor.
@@ -28,6 +23,7 @@ class GetPaymentDetails extends PaymentResourceBase
      */
     public function __construct(VippsInterface $vipps, $subscription_key, $order_id)
     {
+        $this->method = HttpMethod::GET();
         parent::__construct($vipps, $subscription_key);
         $this->id = $order_id;
     }

--- a/src/Resource/Payment/InitiatePayment.php
+++ b/src/Resource/Payment/InitiatePayment.php
@@ -16,14 +16,9 @@ class InitiatePayment extends PaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/ecomm/v2/payments';
+    protected string $path = '/ecomm/v2/payments';
 
     /**
      * InitiatePayment constructor.
@@ -34,6 +29,7 @@ class InitiatePayment extends PaymentResourceBase
      */
     public function __construct(VippsInterface $vipps, $subscription_key, RequestInitiatePayment $requestObject)
     {
+        $this->method = HttpMethod::POST();
         parent::__construct($vipps, $subscription_key);
         $this->body = $this
             ->getSerializer()

--- a/src/Resource/Payment/RefundPayment.php
+++ b/src/Resource/Payment/RefundPayment.php
@@ -16,14 +16,9 @@ class RefundPayment extends PaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/ecomm/v2/payments/{id}/refund';
+    protected string $path = '/ecomm/v2/payments/{id}/refund';
 
     /**
      * InitiatePayment constructor.
@@ -39,6 +34,7 @@ class RefundPayment extends PaymentResourceBase
         $order_id,
         RequestRefundPayment $requestObject
     ) {
+        $this->method = HttpMethod::POST();
         parent::__construct($vipps, $subscription_key);
         $this->body = $this
             ->getSerializer()

--- a/src/Resource/PaymentsInterface.php
+++ b/src/Resource/PaymentsInterface.php
@@ -21,7 +21,7 @@ interface PaymentsInterface extends ResourceInterface
      * @param string $orderID
      * @return $this
      */
-    public function setOrderID($orderID);
+    public function setOrderID(string $orderID): self;
 
     /**
      * Create new payment.
@@ -36,11 +36,11 @@ interface PaymentsInterface extends ResourceInterface
      *   Callback absolute Url.
      * @param string $fallback
      *   Fallback absolute Url.
-     * @param null $refOrderID
+     * @param string|null $refOrderID
      *   (optional) Reference to previous order.
      * @return $this
      */
-    public function create($mobileNumber, $amount, $text, $callback, $fallback, $refOrderID = null);
+    public function create(int $mobileNumber, int $amount, string $text, string $callback, string $fallback, string $refOrderID = null): self;
 
     /**
      * Cancel payment.
@@ -48,7 +48,7 @@ interface PaymentsInterface extends ResourceInterface
      * @param string $text
      * @return $this
      */
-    public function cancel($text);
+    public function cancel(string $text): self;
 
     /**
      * Capture payment.
@@ -59,7 +59,7 @@ interface PaymentsInterface extends ResourceInterface
      *   (optional) Amount in øre.
      * @return $this
      */
-    public function capture($text, $amount = 0);
+    public function capture(string $text, int $amount = 0): self;
 
     /**
      * Refund payment.
@@ -70,7 +70,7 @@ interface PaymentsInterface extends ResourceInterface
      *   (optional) Amount in øre.
      * @return $this
      */
-    public function refund($text, $amount = 0);
+    public function refund(string $text, int $amount = 0): self;
 
     /**
      * Get payment status.

--- a/src/Resource/RecurringPayment/CancelCharge.php
+++ b/src/Resource/RecurringPayment/CancelCharge.php
@@ -19,14 +19,9 @@ class CancelCharge extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::DELETE;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}';
+    protected string $path = '/recurring/v2/agreements/{id}/charges/{charge_id}';
 
     /**
      * CancelCharge constructor.
@@ -45,6 +40,7 @@ class CancelCharge extends RecurringPaymentResourceBase
         $this->id = $agreement_id;
         $this->charge_id = $charge_id;
         parent::__construct($vipps, $subscription_key);
+        $this->method = HttpMethod::DELETE();
     }
 
     /**

--- a/src/Resource/RecurringPayment/CaptureCharge.php
+++ b/src/Resource/RecurringPayment/CaptureCharge.php
@@ -19,14 +19,9 @@ class CaptureCharge extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}/capture';
+    protected string $path = '/recurring/v2/agreements/{id}/charges/{charge_id}/capture';
 
     /**
      * InitiatePayment constructor.
@@ -47,6 +42,7 @@ class CaptureCharge extends RecurringPaymentResourceBase
         // By default RequestID is different for each Resource object.
         $this->headers['Idempotency-Key'] = IdempotencyKeyFactory::generate();
         parent::__construct($vipps, $subscription_key);
+        $this->method = HttpMethod::POST();
     }
 
     /**

--- a/src/Resource/RecurringPayment/CreateAgreement.php
+++ b/src/Resource/RecurringPayment/CreateAgreement.php
@@ -16,14 +16,9 @@ class CreateAgreement extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements';
+    protected string $path = '/recurring/v2/agreements';
 
     /**
      * InitiatePayment constructor.
@@ -35,6 +30,7 @@ class CreateAgreement extends RecurringPaymentResourceBase
     public function __construct(VippsInterface $vipps, $subscription_key, RequestCreateAgreement $requestObject)
     {
         parent::__construct($vipps, $subscription_key);
+        $this->method = HttpMethod::POST();
         $this->body = $this
             ->getSerializer()
             ->serialize(

--- a/src/Resource/RecurringPayment/CreateCharge.php
+++ b/src/Resource/RecurringPayment/CreateCharge.php
@@ -18,14 +18,9 @@ class CreateCharge extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges';
+    protected string $path = '/recurring/v2/agreements/{id}/charges';
 
     /**
      * InitiatePayment constructor.
@@ -45,6 +40,7 @@ class CreateCharge extends RecurringPaymentResourceBase
         // By default RequestID is different for each Resource object.
         $this->headers['Idempotency-Key'] = IdempotencyKeyFactory::generate();
         parent::__construct($vipps, $subscription_key);
+        $this->method = HttpMethod::POST();
         $this->body = $this
             ->getSerializer()
             ->serialize(

--- a/src/Resource/RecurringPayment/GetAgreement.php
+++ b/src/Resource/RecurringPayment/GetAgreement.php
@@ -15,14 +15,9 @@ class GetAgreement extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::GET;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}';
+    protected string $path = '/recurring/v2/agreements/{id}';
 
     /**
      * InitiatePayment constructor.

--- a/src/Resource/RecurringPayment/GetAgreements.php
+++ b/src/Resource/RecurringPayment/GetAgreements.php
@@ -4,6 +4,7 @@ namespace zaporylie\Vipps\Resource\RecurringPayment;
 
 use zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement;
 use zaporylie\Vipps\Resource\HttpMethod;
+use zaporylie\Vipps\VippsInterface;
 
 /**
  * Class GetAgreements
@@ -14,14 +15,9 @@ class GetAgreements extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::GET;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements';
+    protected string $path = '/recurring/v2/agreements';
 
     /**
      * @return \zaporylie\Vipps\Model\RecurringPayment\ResponseGetAgreement[]

--- a/src/Resource/RecurringPayment/GetCharge.php
+++ b/src/Resource/RecurringPayment/GetCharge.php
@@ -14,14 +14,9 @@ class GetCharge extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::GET;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}';
+    protected string $path = '/recurring/v2/agreements/{id}/charges/{charge_id}';
 
     public function __construct(
         \zaporylie\Vipps\VippsInterface $vipps,

--- a/src/Resource/RecurringPayment/GetCharges.php
+++ b/src/Resource/RecurringPayment/GetCharges.php
@@ -12,16 +12,10 @@ use zaporylie\Vipps\Resource\HttpMethod;
  */
 class GetCharges extends RecurringPaymentResourceBase
 {
-
-    /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::GET;
-
     /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges';
+    protected string $path = '/recurring/v2/agreements/{id}/charges';
 
     public function __construct(
         \zaporylie\Vipps\VippsInterface $vipps,

--- a/src/Resource/RecurringPayment/RecurringPaymentResourceBase.php
+++ b/src/Resource/RecurringPayment/RecurringPaymentResourceBase.php
@@ -6,6 +6,7 @@ use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use JMS\Serializer\SerializerBuilder;
 use zaporylie\Vipps\Resource\AuthorizedResourceBase;
+use zaporylie\Vipps\Resource\HttpMethod;
 use zaporylie\Vipps\Resource\RequestIdFactory;
 
 /**
@@ -26,6 +27,7 @@ abstract class RecurringPaymentResourceBase extends AuthorizedResourceBase
      */
     public function __construct(\zaporylie\Vipps\VippsInterface $vipps, $subscription_key)
     {
+        $this->method = HttpMethod::GET();
         parent::__construct($vipps, $subscription_key);
 
         // Adjust serializer.
@@ -49,7 +51,7 @@ abstract class RecurringPaymentResourceBase extends AuthorizedResourceBase
      *
      * All occurrences of {id} pattern will be replaced with $this->id
      */
-    public function getPath()
+    public function getPath(): string
     {
         $path = parent::getPath();
         // If ID is set replace {id} pattern with model's ID.

--- a/src/Resource/RecurringPayment/RefundCharge.php
+++ b/src/Resource/RecurringPayment/RefundCharge.php
@@ -20,14 +20,9 @@ class RefundCharge extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::POST;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}/charges/{charge_id}/refund';
+    protected string $path = '/recurring/v2/agreements/{id}/charges/{charge_id}/refund';
 
     /**
      * RefundCharge constructor.
@@ -50,6 +45,7 @@ class RefundCharge extends RecurringPaymentResourceBase
         // By default RequestID is different for each Resource object.
         $this->headers['Idempotency-Key'] = IdempotencyKeyFactory::generate();
         parent::__construct($vipps, $subscription_key);
+        $this->method = HttpMethod::POST();
         $this->body = $this
             ->getSerializer()
             ->serialize(

--- a/src/Resource/RecurringPayment/UpdateAgreement.php
+++ b/src/Resource/RecurringPayment/UpdateAgreement.php
@@ -16,14 +16,9 @@ class UpdateAgreement extends RecurringPaymentResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected $method = HttpMethod::PATCH;
-
-    /**
      * @var string
      */
-    protected $path = '/recurring/v2/agreements/{id}';
+    protected string $path = '/recurring/v2/agreements/{id}';
 
     /**
      * InitiatePayment constructor.
@@ -40,6 +35,7 @@ class UpdateAgreement extends RecurringPaymentResourceBase
         RequestUpdateAgreement $requestObject
     ) {
         parent::__construct($vipps, $subscription_key);
+        $this->method = HttpMethod::PATCH();
         $this->id = $agreement_id;
         $this->body = $this
             ->getSerializer()

--- a/src/Resource/RequestIdFactory.php
+++ b/src/Resource/RequestIdFactory.php
@@ -15,7 +15,7 @@ abstract class RequestIdFactory
      *
      * @return string
      */
-    public static function generate()
+    public static function generate(): string
     {
         return uniqid('', true);
     }

--- a/src/Resource/ResourceBase.php
+++ b/src/Resource/ResourceBase.php
@@ -12,9 +12,11 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use JMS\Serializer\Serializer;
 use JMS\Serializer\SerializerBuilder;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
 use zaporylie\Vipps\Exceptions\VippsException;
 use zaporylie\Vipps\VippsInterface;
 
@@ -28,37 +30,37 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
     /**
      * @var VippsInterface
      */
-    protected $app;
+    protected VippsInterface $app;
 
     /**
      * @var array
      */
-    protected $headers = [];
+    protected array $headers = [];
 
     /**
      * @var string
      */
-    protected $body = '';
+    protected string $body = '';
 
     /**
      * @var string
      */
-    protected $id;
+    protected string $id;
 
     /**
      * @var string
      */
-    protected $path;
+    protected string $path;
 
     /**
      * @var \zaporylie\Vipps\Resource\HttpMethod
      */
-    protected $method;
+    protected HttpMethod $method;
 
     /**
      * @var \JMS\Serializer\Serializer
      */
-    protected $serializer;
+    protected Serializer $serializer;
 
     /**
      * AbstractResource constructor.
@@ -85,7 +87,7 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
      *
      * @return \JMS\Serializer\Serializer
      */
-    public function getSerializer()
+    public function getSerializer(): Serializer
     {
         return $this->serializer;
     }
@@ -93,7 +95,7 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -101,7 +103,7 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
     /**
      * {@inheritdoc}
      */
-    public function getMethod()
+    public function getMethod(): HttpMethod
     {
         if (!isset($this->method)) {
             throw new \LogicException('Missing HTTP method');
@@ -114,7 +116,7 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
      *
      * All occurrences of {id} pattern will be replaced with $this->id
      */
-    public function getPath()
+    public function getPath(): string
     {
         if (!isset($this->path)) {
             throw new \LogicException('Missing resource path');
@@ -135,7 +137,7 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
      *
      * @return $this
      */
-    public function setPath($path)
+    public function setPath($path): self
     {
         $this->path = $path;
         return $this;
@@ -144,7 +146,7 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
     /**
      * @return string
      */
-    public function getBody()
+    public function getBody(): string
     {
         return $this->body;
     }
@@ -154,7 +156,7 @@ abstract class ResourceBase implements ResourceInterface, SerializableInterface
      *
      * @return \Psr\Http\Message\UriInterface
      */
-    public function getUri($path)
+    public function getUri($path): UriInterface
     {
         return $this->app->getClient()->getEndpoint()->getUri()->withPath($path);
     }

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -22,7 +22,7 @@ interface ResourceInterface
      * @return string
      * @throws \LogicException
      */
-    public function getPath();
+    public function getPath(): string;
 
     /**
      * HTTP method.
@@ -30,7 +30,7 @@ interface ResourceInterface
      * @return \zaporylie\Vipps\Resource\HttpMethod
      * @throws \LogicException
      */
-    public function getMethod();
+    public function getMethod(): HttpMethod;
 
     /**
      * HTTP headers.
@@ -38,7 +38,7 @@ interface ResourceInterface
      * @return array
      * @throws \LogicException
      */
-    public function getHeaders();
+    public function getHeaders(): array;
 
     /**
      * @return mixed

--- a/src/Resource/UserInfo/UserInfo.php
+++ b/src/Resource/UserInfo/UserInfo.php
@@ -19,12 +19,12 @@ class UserInfo extends AuthorizedResourceBase
     /**
      * @var \zaporylie\Vipps\Resource\HttpMethod
      */
-    protected $method = HttpMethod::GET;
+    protected HttpMethod $method = HttpMethod::GET;
 
     /**
      * @var string
      */
-    protected $path = '/vipps-userinfo-api/userinfo/{id}';
+    protected string $path = '/vipps-userinfo-api/userinfo/{id}';
 
     /**
      * AbstractResource constructor.

--- a/src/Resource/UserInfo/UserInfo.php
+++ b/src/Resource/UserInfo/UserInfo.php
@@ -17,11 +17,6 @@ class UserInfo extends AuthorizedResourceBase
 {
 
     /**
-     * @var \zaporylie\Vipps\Resource\HttpMethod
-     */
-    protected HttpMethod $method = HttpMethod::GET;
-
-    /**
      * @var string
      */
     protected string $path = '/vipps-userinfo-api/userinfo/{id}';
@@ -42,6 +37,7 @@ class UserInfo extends AuthorizedResourceBase
             $this->app->getClient()->getTokenStorage()->get()->getTokenType()
             .' '.
             $this->app->getClient()->getTokenStorage()->get()->getAccessToken();
+        $this->method = HttpMethod::GET();
     }
 
     /**

--- a/src/Vipps.php
+++ b/src/Vipps.php
@@ -9,9 +9,13 @@
 namespace zaporylie\Vipps;
 
 use zaporylie\Vipps\Api\Authorization;
+use zaporylie\Vipps\Api\AuthorizationInterface;
 use zaporylie\Vipps\Api\Payment;
+use zaporylie\Vipps\Api\PaymentInterface;
 use zaporylie\Vipps\Api\RecurringPayment;
+use zaporylie\Vipps\Api\RecurringPaymentInterface;
 use zaporylie\Vipps\Api\UserInfo;
+use zaporylie\Vipps\Api\UserInfoInterface;
 
 /**
  * Class Vipps
@@ -23,7 +27,7 @@ class Vipps implements VippsInterface
     /**
      * @var \zaporylie\Vipps\ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * Vipps constructor.
@@ -38,7 +42,7 @@ class Vipps implements VippsInterface
     /**
      * {@inheritdoc}
      */
-    public function getClient()
+    public function getClient(): ClientInterface
     {
         return $this->client;
     }
@@ -48,9 +52,9 @@ class Vipps implements VippsInterface
      * @param string $merchant_serial_number
      * @param string $custom_path
      *
-     * @return \zaporylie\Vipps\Api\Payment
+     * @return \zaporylie\Vipps\Api\PaymentInterface
      */
-    public function payment($subscription_key, $merchant_serial_number, $custom_path = 'ecomm')
+    public function payment(string $subscription_key, string $merchant_serial_number, string $custom_path = 'ecomm'): PaymentInterface
     {
         return new Payment($this, $subscription_key, $merchant_serial_number, $custom_path);
     }
@@ -61,7 +65,7 @@ class Vipps implements VippsInterface
      *
      * @return \zaporylie\Vipps\Api\RecurringPaymentInterface
      */
-    public function recurringPayment($subscription_key, $merchant_serial_number)
+    public function recurringPayment(string $subscription_key, string $merchant_serial_number): RecurringPaymentInterface
     {
         return new RecurringPayment($this, $subscription_key, $merchant_serial_number);
     }
@@ -69,7 +73,7 @@ class Vipps implements VippsInterface
     /**
      * @return \zaporylie\Vipps\Api\UserInfoInterface
      */
-    public function userInfo()
+    public function userInfo(): UserInfoInterface
     {
         return new UserInfo($this);
     }
@@ -77,9 +81,9 @@ class Vipps implements VippsInterface
     /**
      * @param string $subscription_key
      *
-     * @return \zaporylie\Vipps\Api\Authorization
+     * @return \zaporylie\Vipps\Api\AuthorizationInterface
      */
-    public function authorization($subscription_key)
+    public function authorization(string $subscription_key): AuthorizationInterface
     {
         return new Authorization($this, $subscription_key);
     }

--- a/src/VippsInterface.php
+++ b/src/VippsInterface.php
@@ -8,8 +8,14 @@
 
 namespace zaporylie\Vipps;
 
+use zaporylie\Vipps\Api\AuthorizationInterface;
+use zaporylie\Vipps\Api\PaymentInterface;
+use zaporylie\Vipps\Api\RecurringPaymentInterface;
+use zaporylie\Vipps\Api\UserInfoInterface;
+
 /**
  * Interface VippsInterface
+ *
  * @package Vipps
  */
 interface VippsInterface
@@ -18,14 +24,19 @@ interface VippsInterface
     /**
      * @return \zaporylie\Vipps\ClientInterface
      */
-    public function getClient();
+    public function getClient(): ClientInterface;
 
     /**
      * @param string $subscription_key
      *
      * @return \zaporylie\Vipps\Api\AuthorizationInterface
      */
-    public function authorization($subscription_key);
+    public function authorization(string $subscription_key): AuthorizationInterface;
+
+    /**
+     * @return \zaporylie\Vipps\UserInfoInterface
+     */
+    public function userInfo(): UserInfoInterface;
 
     /**
      * @param string $subscription_key
@@ -34,7 +45,7 @@ interface VippsInterface
      *
      * @return \zaporylie\Vipps\Api\PaymentInterface
      */
-    public function payment($subscription_key, $merchant_serial_number, $custom_path);
+    public function payment(string $subscription_key, string $merchant_serial_number, string $custom_path): PaymentInterface;
 
     /**
      * @param string $subscription_key
@@ -42,5 +53,5 @@ interface VippsInterface
      *
      * @return \zaporylie\Vipps\Api\RecurringPaymentInterface
      */
-    public function recurringPayment($subscription_key, $merchant_serial_number);
+    public function recurringPayment(string $subscription_key, string $merchant_serial_number): RecurringPaymentInterface;
 }

--- a/test/Unit/Api/ApiBaseTest.php
+++ b/test/Unit/Api/ApiBaseTest.php
@@ -38,8 +38,5 @@ class ApiBaseTest extends TestCase
     public function testSubscriptionKey()
     {
         $this->assertEquals('test_subscription_key', $this->apiBase->getSubscriptionKey());
-        $this->assertInstanceOf(ApiBase::class, $this->apiBase->setSubscriptionKey(null));
-        $this->expectException(InvalidArgumentException::class);
-        $this->apiBase->getSubscriptionKey();
     }
 }

--- a/test/Unit/Api/PaymentTest.php
+++ b/test/Unit/Api/PaymentTest.php
@@ -21,9 +21,6 @@ class PaymentTest extends TestCase
         $vipps = $this->createMock(Vipps::class);
         $api = new Payment($vipps, 'test_subscription_key', 'test_merchant_serial_number');
         $this->assertEquals('test_merchant_serial_number', $api->getMerchantSerialNumber());
-        $api = new Payment($vipps, 'test_subscription_key', null);
-        $this->expectException(InvalidArgumentException::class);
-        $api->getMerchantSerialNumber();
     }
 
     /**

--- a/test/Unit/Authentication/TestTokenStorage.php
+++ b/test/Unit/Authentication/TestTokenStorage.php
@@ -7,7 +7,7 @@ use zaporylie\Vipps\Model\Authorization\ResponseGetToken;
 
 class TestTokenStorage extends TokenMemoryCacheStorage
 {
-    public function get()
+    public function get(): ResponseGetToken
     {
         $token = new ResponseGetToken();
 

--- a/test/Unit/ClientTest.php
+++ b/test/Unit/ClientTest.php
@@ -42,9 +42,6 @@ class ClientTest extends TestCase
     public function testClientId()
     {
         $this->assertEquals('test', $this->client->getClientId());
-        $this->assertInstanceOf(ClientInterface::class, $this->client->setClientId(null));
-        $this->expectException(InvalidArgumentException::class);
-        $this->client->getClientId();
     }
 
     /**

--- a/test/Unit/Model/UserInfo/AccountInfoTest.php
+++ b/test/Unit/Model/UserInfo/AccountInfoTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace zaporylie\Vipps\Tests\Unit\Model\UserInfo;
+
+use JMS\Serializer\SerializerBuilder;
+use zaporylie\Vipps\Model\UserInfo\AccountInfo;
+use zaporylie\Vipps\Tests\Unit\Model\ModelTestBase;
+
+class AccountInfoTest extends ModelTestBase
+{
+
+    /**
+     * @var \zaporylie\Vipps\Model\UserInfo\AccountInfo
+     */
+    protected $model;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+        $data = [
+            "account_name" => "Savings account",
+            "account_number" => 86011117947,
+            "bank_name" => "ACME Bank"
+        ];
+        $serializer = SerializerBuilder::create()->build();
+        $this->model = $serializer->deserialize(json_encode($data), AccountInfo::class, 'json');
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\AccountInfo::getAccountName()
+     */
+    public function testGetAccountName()
+    {
+        $this->assertEquals('Savings account', $this->model->getAccountName());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\AccountInfo::getAccountNumber()
+     */
+    public function testGetAccountNumber()
+    {
+        $this->assertEquals(86011117947, $this->model->getAccountNumber());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\AccountInfo::getBankName()
+     */
+    public function testGetBankName()
+    {
+        $this->assertEquals('ACME Bank', $this->model->getBankName());
+    }
+}

--- a/test/Unit/Model/UserInfo/AddressTest.php
+++ b/test/Unit/Model/UserInfo/AddressTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace zaporylie\Vipps\Tests\Unit\Model\UserInfo;
+
+use JMS\Serializer\SerializerBuilder;
+use zaporylie\Vipps\Model\UserInfo\AccountInfo;
+use zaporylie\Vipps\Model\UserInfo\Address;
+use zaporylie\Vipps\Tests\Unit\Model\ModelTestBase;
+
+class AddressTest extends ModelTestBase
+{
+
+    /**
+     * @var \zaporylie\Vipps\Model\UserInfo\Address
+     */
+    protected $model;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+        $data = [
+            "address_type" => "home",
+            "country" => "NO",
+            "default" => true,
+            "formatted" => "Robert Levins gate 5\n0154 Oslo",
+            "postal_code" => "0154",
+            "region" => "Oslo",
+            "street_address" => "Robert Levins gate 5"
+        ];
+        $serializer = SerializerBuilder::create()->build();
+        $this->model = $serializer->deserialize(json_encode($data), Address::class, 'json');
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\Address::getAddressType()
+     */
+    public function testGetAddressType()
+    {
+        $this->assertEquals('home', $this->model->getAddressType());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\Address::getCountry
+     */
+    public function testGetCountry()
+    {
+        $this->assertEquals('NO', $this->model->getCountry());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\Address::getFormatted
+     */
+    public function testGetFormatted()
+    {
+        $this->assertEquals("Robert Levins gate 5\n0154 Oslo", $this->model->getFormatted());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\Address::getPostalCode
+     */
+    public function testGetPostalCode()
+    {
+        $this->assertEquals('0154', $this->model->getPostalCode());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\Address::getRegion
+     */
+    public function testGetRegion()
+    {
+        $this->assertEquals('Oslo', $this->model->getRegion());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\Address::getStreetAddress
+     */
+    public function testGetStreetAddress()
+    {
+        $this->assertEquals('Robert Levins gate 5', $this->model->getStreetAddress());
+    }
+}

--- a/test/Unit/Model/UserInfo/ResponseUserInfoTest.php
+++ b/test/Unit/Model/UserInfo/ResponseUserInfoTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace zaporylie\Vipps\Tests\Unit\Model\UserInfo;
+
+use zaporylie\Vipps\Model\Payment\ResponseGetOrderStatus;
+use zaporylie\Vipps\Model\Payment\TransactionInfo;
+use zaporylie\Vipps\Model\UserInfo\Address;
+use zaporylie\Vipps\Model\UserInfo\ResponseUserInfo;
+use zaporylie\Vipps\Resource\Payment\GetOrderStatus;
+use zaporylie\Vipps\Resource\UserInfo\UserInfo;
+use zaporylie\Vipps\Tests\Unit\Model\ModelTestBase;
+
+class ResponseUserInfoTest extends ModelTestBase
+{
+
+    /**
+     * @var \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo
+     */
+    protected $model;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+        $resource = new UserInfo($this->vipps, 'test');
+        $this->model = $resource->getSerializer()->deserialize(
+            json_encode((object) [
+                "accounts" => [[
+                    "account_name" => "Savings account",
+                    "account_number" => 86011117947,
+                    "bank_name" => "ACME Bank"
+                ]],
+                "address" => [
+                    "address_type" => "home",
+                    "country" => "NO",
+                    "default" => true,
+                    "formatted" => "Robert Levins gate 5\n0154 Oslo",
+                    "postal_code" => "0154",
+                    "region" => "Oslo",
+                    "street_address" => "Robert Levins gate 5"
+                ],
+                "other_addresses" => [[
+                    "address_type" => "home",
+                    "country" => "NO",
+                    "default" => true,
+                    "formatted" => "Robert Levins gate 5\n0154 Oslo",
+                    "postal_code" => "0154",
+                    "region" => "Oslo",
+                    "street_address" => "Robert Levins gate 5"
+                ]],
+                "birthdate" => "2000-12-31",
+                "email" => "user@example.com",
+                "email_verified" => true,
+                "family_name" => "Lovelace",
+                "given_name" => "Ada",
+                "name" => "Ada Lovelace",
+                "nin" => "09057517287",
+                "phone_number" => "47912345678",
+                "sid" => "7d78a726-af92-499e-b857-de263ef9a969",
+                "sub" => "c06c4afe-d9e1-4c5d-939a-177d752a0944"
+            ]),
+            ResponseUserInfo::class,
+            'json'
+        );
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getAccounts
+     */
+    public function testGetAccounts()
+    {
+        $this->assertIsArray($this->model->getAccounts());
+        $this->assertNotEmpty($this->model->getAccounts());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getAddress
+     */
+    public function testGetAddress()
+    {
+        $this->assertInstanceOf(Address::class, $this->model->getAddress());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getBirthdate
+     */
+    public function testGetBirthday()
+    {
+        $this->assertEquals('2000-12-31', $this->model->getBirthdate());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getEmail
+     */
+    public function testGetEmail()
+    {
+        $this->assertEquals('user@example.com', $this->model->getEmail());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getFamilyName
+     */
+    public function testGetFamilyName()
+    {
+        $this->assertEquals('Lovelace', $this->model->getFamilyName());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getGivenName
+     */
+    public function testGetGivenName()
+    {
+        $this->assertEquals('Ada', $this->model->getGivenName());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getName
+     */
+    public function testGetName()
+    {
+        $this->assertEquals('Ada Lovelace', $this->model->getName());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getNin
+     */
+    public function testGetNin()
+    {
+        $this->assertEquals('09057517287', $this->model->getNin());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getPhoneNumber
+     */
+    public function testGetPhoneNumber()
+    {
+        $this->assertEquals('47912345678', $this->model->getPhoneNumber());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getSid
+     */
+    public function testGetSid()
+    {
+        $this->assertEquals('7d78a726-af92-499e-b857-de263ef9a969', $this->model->getSid());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getSub
+     */
+    public function testGetSub()
+    {
+        $this->assertEquals('c06c4afe-d9e1-4c5d-939a-177d752a0944', $this->model->getSub());
+    }
+
+    /**
+     * @covers \zaporylie\Vipps\Model\UserInfo\ResponseUserInfo::getOtherAddresses
+     */
+    public function testGetOtherAddresses()
+    {
+        $this->assertIsArray($this->model->getOtherAddresses());
+        $this->assertNotEmpty($this->model->getOtherAddresses());
+    }
+}

--- a/test/Unit/Resource/ResourceBaseTest.php
+++ b/test/Unit/Resource/ResourceBaseTest.php
@@ -40,7 +40,7 @@ class ResourceBaseTest extends ResourceTestBase
         $reflection = new \ReflectionClass($this->resourceBase);
         $method = $reflection->getProperty('method');
         $method->setAccessible(true);
-        $method->setValue($this->resourceBase, HttpMethod::POST);
+        $method->setValue($this->resourceBase, HttpMethod::POST());
 
         // Set default body.
         $body = $reflection->getProperty('body');
@@ -87,10 +87,8 @@ class ResourceBaseTest extends ResourceTestBase
         $reflection = new \ReflectionClass($this->resourceBase);
         $method = $reflection->getProperty('method');
         $method->setAccessible(true);
+        $this->expectError();
         $method->setValue($this->resourceBase, null);
-
-        $this->expectException(\LogicException::class);
-        $this->resourceBase->getMethod();
     }
 
     /**
@@ -103,10 +101,8 @@ class ResourceBaseTest extends ResourceTestBase
         $reflection = new \ReflectionClass($this->resourceBase);
         $path = $reflection->getProperty('path');
         $path->setAccessible(true);
+        $this->expectError();
         $path->setValue($this->resourceBase, null);
-
-        $this->expectException(\LogicException::class);
-        $this->resourceBase->getPath();
     }
 
     /**


### PR DESCRIPTION
As part of this PR support for php 7.2 and 7.3 is dropped. Also, PHP 8.1 and 8.2 are added to the test matrix.  Given the base branch for this PR is 3.x I am also planning to add support for typed properties.